### PR TITLE
fix: trim image src

### DIFF
--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -308,7 +308,7 @@ class Downloader {
 
 			$post_content_updated = $post->post_content;
 			foreach ( $img_data as $img_datum ) {
-				$src   = $img_datum[0];
+				$src   = trim( $img_datum[0] );
 				$title = $img_datum[1];
 				$alt   = $img_datum[2];
 

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -229,47 +229,52 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * @return array[]
 	 */
 	public function providerUriHostMatching() {
-		 return array(
-			 array(
-				 'https://host1.com/path/img.jpg',
-				 array( 'host1.com' ),
-				 true,
-			 ),
-			 array(
-				 'https://host1.com/path/img.jpg',
-				 array( 'host2.com' ),
-				 false,
-			 ),
-			 array(
-				 'https://host1.com/path/img.jpg',
-				 array( '*.host1.com' ),
-				 false,
-			 ),
-			 array(
-				 'https://host1.com/path/img.jpg',
-				 array( 'host1.*' ),
-				 true,
-			 ),
-			 array(
-				 'https://host1.com/path/img.jpg',
-				 array( '*.host1.*' ),
-				 false,
-			 ),
-			 array(
-				 'https://www.host1.com/path/img.jpg',
-				 array( '*.host1.com' ),
-				 true,
-			 ),
-			 array(
-				 'https://www.host1.com/path/img.jpg',
-				 array( 'www.host1.*' ),
-				 true,
-			 ),
-			 array(
-				 'https://www.host1.com/path/img.jpg',
-				 array( 'www.host2.*' ),
-				 true,
-			 ),
-		 );
+		return array(
+			array(
+				'https://host1.com/path/img.jpg',
+				array( 'host1.com' ),
+				true,
+			),
+			array(
+				'    https://host1.com/path/with-spaces.jpg    ',
+				array( 'host1.com' ),
+				true,
+			),
+			array(
+				'https://host1.com/path/img.jpg',
+				array( 'host2.com' ),
+				false,
+			),
+			array(
+				'https://host1.com/path/img.jpg',
+				array( '*.host1.com' ),
+				false,
+			),
+			array(
+				'https://host1.com/path/img.jpg',
+				array( 'host1.*' ),
+				true,
+			),
+			array(
+				'https://host1.com/path/img.jpg',
+				array( '*.host1.*' ),
+				false,
+			),
+			array(
+				'https://www.host1.com/path/img.jpg',
+				array( '*.host1.com' ),
+				true,
+			),
+			array(
+				'https://www.host1.com/path/img.jpg',
+				array( 'www.host1.*' ),
+				true,
+			),
+			array(
+				'https://www.host1.com/path/img.jpg',
+				array( 'www.host2.*' ),
+				true,
+			),
+		);
 	}
 }


### PR DESCRIPTION
## Changes proposed in this PR

Trim image src to ensure `wp_parse_url` is able to interpret the src string.

If you send an untrimmed string, the function is not able to return the `host`, e.g.:

```
// Untrimmed
wp_parse_url('  https://host.com/img.jpg');
Array
(
    [path] =>   https://host.com/img.jpg
)

// Trimmed
wp_parse_url('https://host.com/img.jpg');
Array
(
    [scheme] => https
    [host] => host.com
    [path] => /img.jpg
)
```

Without the `host` value properly set, the `does_uri_match_host()` check does not work as expected and skips matching hosts.