### PR TITLE
Add image deduping

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
   <rule ref="WordPress-VIP-Go" />
 
   <rule ref="PHPCompatibilityWP"/>
-  <config name="testVersion" value="7.0-"/>
+  <config name="testVersion" value="7.4-"/>
 
   <arg name="extensions" value="php"/>
 

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -551,6 +551,7 @@ class Downloader {
 
 					$replaced_src = $dupe[ 'src' ];
 					$replaced_id  = $dupe[ 'ID' ];
+					$replacement_done = false;
 
 					// Update the Post's Featured Image, if this $replaced_id dupe was used.
 					if ( $replaced_id == $post_featured_img_id ) {
@@ -571,13 +572,15 @@ class Downloader {
 
 						$block_html_updated = $this->image_block_update_image( $block_html, $first_id, $first_src );
 						$post_content_updated = str_replace( $block_html, $block_html_updated, $post_content_updated );
+						$replacement_done = true;
 					}
 
 					// Also replace plain `src`s in non-block content.
+					$replacement_done = $replacement_done || strpos( $post_content_updated, $replaced_src );
 					$post_content_updated = str_replace( $replaced_src, $first_src, $post_content_updated );
 
 					// Log the `src` update.
-					if ( $post_content_updated != $post->post_content ) {
+					if ( $replacement_done ) {
 						$log_post .= "\n" . sprintf( '✔ ID %d %s replaced with ID %d %s', $replaced_id, $replaced_src, $first_id, $first_src );
 					}
 				}

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1039,7 +1039,7 @@ class Downloader {
 		// Replace the src image by keeping all image customizations.
 		$block_html_updated = str_replace( $src_block, $new_src_customized, $block_html_updated );
 
-		// Replace string's class name.
+		// Replace ID in class name.
 		$block_html_updated = str_replace( sprintf( 'class="wp-image-%d"', $id_block ), sprintf( 'class="wp-image-%d"', $new_id ), $block_html_updated );
 
 		return $block_html_updated;

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -289,6 +289,13 @@ class Downloader {
 		WP_CLI::line( sprintf( 'Done in %d mins! 🙌 ', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
 	}
 
+	/**
+	 * Callable for `newspack-post-image-downloader import-images`.
+	 * See command description in \NewspackPostImageDownloader\Downloader::register_commands.
+	 *
+	 * @param array $args       CLI arguments.
+	 * @param array $assoc_args CLI associative arguments.
+	 */
 	public function cmd_import_images( $args, $assoc_args ) {
 		$dry_run                       = isset( $assoc_args['dry-run'] ) ? true : false;
 		$post_types                    = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : array( 'post', 'page' );

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1008,7 +1008,7 @@ class Downloader {
 		$block_html_updated = $block_html;
 		$id_block           = $this->block_manipulator->get_block_attribute_value( $block_html_updated, 'id' );
 		$srcs_block         = $this->get_all_img_srcs( $block_html );
-		// TODO Improve to using $this->dom_crawler.
+		// TODO Improve by using $this->dom_crawler.
 		$src_block = $srcs_block[0] ?? null;
 		if ( ! $src_block ) {
 			return $block_html;

--- a/src/class-wpblockmanipulator.php
+++ b/src/class-wpblockmanipulator.php
@@ -22,7 +22,7 @@ class WpBlockManipulator {
 		%1$s        # element name/designation, should be substituted by using sprintf(), eg. sprintf( $this_pattern, \'wp:video\' );
 		\s          # followed by a space
 		--\>)       # end of block
-				    # "s" modifier also needed here to match accross multi-lines
+				    # "s" modifier also needed here to match across multi-lines
 		|xims';
 
 
@@ -92,12 +92,10 @@ class WpBlockManipulator {
 			$json_part_updated = json_encode( $attributes );
 			$block_element_1st_line_patched = str_replace( $json_part, $json_part_updated, $block_element_1st_line );
 		} else {
-			// Add attributes section.
+			// Insert the whole attributes section.
 			$json_part = json_encode( [ $attribute => $new_value ] );
 			$pos_closing = strpos( $block_element_1st_line, '-->' );
-			$block_element_1st_line_patched = substr( $block_element_1st_line, 0, $pos_closing )
-			                                  . $json_part
-			                                  . ' -->';
+			$block_element_1st_line_patched = substr( $block_element_1st_line, 0, $pos_closing ) . $json_part . ' -->';
 		}
 
 		$block_element_lines[0] = $block_element_1st_line_patched;

--- a/src/class-wpblockmanipulator.php
+++ b/src/class-wpblockmanipulator.php
@@ -22,7 +22,7 @@ class WpBlockManipulator {
 		%1$s        # element name/designation, should be substituted by using sprintf(), eg. sprintf( $this_pattern, \'wp:video\' );
 		\s          # followed by a space
 		--\>)       # end of block
-				    # "s" modifier also needed here to match across multi-lines
+					# "s" modifier needed to match across multi-lines
 		|xims';
 
 

--- a/src/class-wpblockmanipulator.php
+++ b/src/class-wpblockmanipulator.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace NewspackPostImageDownloader;
+
+/**
+ * WP Blocks manipulator class.
+ *
+ * @package NewspackPostImageDownloader
+ */
+class WpBlockManipulator {
+
+	const BLOCK_PATTERN = '|
+		\<\!--      # beginning of the block element
+		\s          # followed by a space
+		%1$s        # element name/designation, should be substituted by using sprintf(), eg. sprintf( $this_pattern, \'wp:video\' );
+		.*?         # anything in the middle
+		--\>        # end of opening tag
+		.*?         # anything in the middle
+		(\<\!--     # beginning of the closing tag
+		\s          # followed by a space
+		/           # one forward slash
+		%1$s        # element name/designation, should be substituted by using sprintf(), eg. sprintf( $this_pattern, \'wp:video\' );
+		\s          # followed by a space
+		--\>)       # end of block
+				    # "s" modifier also needed here to match accross multi-lines
+		|xims';
+
+
+	/**
+	 * Searches and matches block elements in given source.
+	 * Runs the preg_match_all() with the PREG_OFFSET_CAPTURE option, and returns the $match.
+	 *
+	 * @param string $block_name Block name to search for (match).
+	 * @param string $content    Blocks content source in which to search for blocks.
+	 *
+	 * @return array|null| $matches from the preg_match_all() or null.
+	 */
+	public function match_wp_blocks( $block_name, $content ) {
+
+		$pattern = sprintf( self::BLOCK_PATTERN, $block_name );
+		$preg_match_all_result = preg_match_all( $pattern, $content, $matches, PREG_OFFSET_CAPTURE );
+
+		return ( false === $preg_match_all_result || 0 === $preg_match_all_result ) ? null : $matches;
+	}
+
+	/**
+	 * Gets Block attribute value.
+	 *
+	 * @param string $block_element Block element source.
+	 * @param string $attribute     Block attribute name.
+	 *
+	 * @return mixed|null
+	 */
+	public function get_block_attribute_value( $block_element, $attribute ) {
+		$block_element_lines    = explode( "\n", $block_element );
+		$block_element_1st_line = $block_element_lines[0];
+
+		$pos_from_curly = strpos( $block_element_1st_line, '{' );
+		$pos_to_curly = strpos( $block_element_1st_line, '}' );
+		$contains_existing_attributes = $pos_from_curly && $pos_to_curly;
+		if ( ! $contains_existing_attributes ) {
+			return null;
+		}
+
+		$json_part = substr( $block_element_1st_line, $pos_from_curly, $pos_to_curly - $pos_from_curly + 1 );
+		$attributes = \json_decode( $json_part, true );
+
+		return $attributes[ $attribute ] ?? null;
+	}
+
+	/**
+	 * Updates or sets Block attribute.
+	 *
+	 * @param string $block_element Block element full source.
+	 * @param string $attribute     Attribute name.
+	 * @param mixed  $new_value     Attribute value.
+	 *
+	 * @return string Updated Block element full source.
+	 */
+	public function update_block_attribute( $block_element, $attribute, $new_value ) {
+		$block_element_lines    = explode( "\n", $block_element );
+		$block_element_1st_line = $block_element_lines[0];
+
+		$pos_from_curly = strpos( $block_element_1st_line, '{' );
+		$pos_to_curly = strpos( $block_element_1st_line, '}' );
+		$contains_existing_attributes = $pos_from_curly && $pos_to_curly;
+		// Update attributes section if already exists.
+		if ( $contains_existing_attributes ) {
+			$json_part = substr( $block_element_1st_line, $pos_from_curly, $pos_to_curly - $pos_from_curly + 1 );
+			$attributes = \json_decode( $json_part, true );
+			$attributes[ $attribute ] = $new_value;
+			$json_part_updated = json_encode( $attributes );
+			$block_element_1st_line_patched = str_replace( $json_part, $json_part_updated, $block_element_1st_line );
+		} else {
+			// Add attributes section.
+			$json_part = json_encode( [ $attribute => $new_value ] );
+			$pos_closing = strpos( $block_element_1st_line, '-->' );
+			$block_element_1st_line_patched = substr( $block_element_1st_line, 0, $pos_closing )
+			                                  . $json_part
+			                                  . ' -->';
+		}
+
+		$block_element_lines[0] = $block_element_1st_line_patched;
+		$block_element_patched  = implode( "\n", $block_element_lines );
+
+		return $block_element_patched;
+	}
+}

--- a/src/class-wpblockmanipulator.php
+++ b/src/class-wpblockmanipulator.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * WP Block Manipulator.
+ *
+ * @package Newspack_Post_Image_Downloader
+ */
 
 namespace NewspackPostImageDownloader;
 
@@ -37,7 +42,7 @@ class WpBlockManipulator {
 	 */
 	public function match_wp_blocks( $block_name, $content ) {
 
-		$pattern = sprintf( self::BLOCK_PATTERN, $block_name );
+		$pattern               = sprintf( self::BLOCK_PATTERN, $block_name );
 		$preg_match_all_result = preg_match_all( $pattern, $content, $matches, PREG_OFFSET_CAPTURE );
 
 		return ( false === $preg_match_all_result || 0 === $preg_match_all_result ) ? null : $matches;
@@ -55,14 +60,14 @@ class WpBlockManipulator {
 		$block_element_lines    = explode( "\n", $block_element );
 		$block_element_1st_line = $block_element_lines[0];
 
-		$pos_from_curly = strpos( $block_element_1st_line, '{' );
-		$pos_to_curly = strpos( $block_element_1st_line, '}' );
+		$pos_from_curly               = strpos( $block_element_1st_line, '{' );
+		$pos_to_curly                 = strpos( $block_element_1st_line, '}' );
 		$contains_existing_attributes = $pos_from_curly && $pos_to_curly;
 		if ( ! $contains_existing_attributes ) {
 			return null;
 		}
 
-		$json_part = substr( $block_element_1st_line, $pos_from_curly, $pos_to_curly - $pos_from_curly + 1 );
+		$json_part  = substr( $block_element_1st_line, $pos_from_curly, $pos_to_curly - $pos_from_curly + 1 );
 		$attributes = \json_decode( $json_part, true );
 
 		return $attributes[ $attribute ] ?? null;
@@ -81,20 +86,20 @@ class WpBlockManipulator {
 		$block_element_lines    = explode( "\n", $block_element );
 		$block_element_1st_line = $block_element_lines[0];
 
-		$pos_from_curly = strpos( $block_element_1st_line, '{' );
-		$pos_to_curly = strpos( $block_element_1st_line, '}' );
+		$pos_from_curly               = strpos( $block_element_1st_line, '{' );
+		$pos_to_curly                 = strpos( $block_element_1st_line, '}' );
 		$contains_existing_attributes = $pos_from_curly && $pos_to_curly;
 		// Update attributes section if already exists.
 		if ( $contains_existing_attributes ) {
-			$json_part = substr( $block_element_1st_line, $pos_from_curly, $pos_to_curly - $pos_from_curly + 1 );
-			$attributes = \json_decode( $json_part, true );
-			$attributes[ $attribute ] = $new_value;
-			$json_part_updated = json_encode( $attributes );
+			$json_part                      = substr( $block_element_1st_line, $pos_from_curly, $pos_to_curly - $pos_from_curly + 1 );
+			$attributes                     = \json_decode( $json_part, true );
+			$attributes[ $attribute ]       = $new_value;
+			$json_part_updated              = json_encode( $attributes );
 			$block_element_1st_line_patched = str_replace( $json_part, $json_part_updated, $block_element_1st_line );
 		} else {
 			// Insert the whole attributes section.
-			$json_part = json_encode( [ $attribute => $new_value ] );
-			$pos_closing = strpos( $block_element_1st_line, '-->' );
+			$json_part                      = json_encode( array( $attribute => $new_value ) );
+			$pos_closing                    = strpos( $block_element_1st_line, '-->' );
 			$block_element_1st_line_patched = substr( $block_element_1st_line, 0, $pos_closing ) . $json_part . ' -->';
 		}
 

--- a/tests/fixtures/class-dataproviderwpblockmanipulator.php
+++ b/tests/fixtures/class-dataproviderwpblockmanipulator.php
@@ -34,7 +34,7 @@ class DataProviderWPBlockManipulator {
 CONTENT;
 	}
 
-	public function get_content_with_no_blocks() {
+	public function get_content_with_no_image_blocks() {
 		return <<<CONTENT
 <!-- wp:paragraph -->
 <p>some text</p>

--- a/tests/fixtures/class-dataproviderwpblockmanipulator.php
+++ b/tests/fixtures/class-dataproviderwpblockmanipulator.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Data Provider for tests.
+ *
+ * @package Newspack
+ */
+
+namespace NewspackPostImageDownloaderTest;
+
+/**
+ * Class DataProviderWPBlockManipulator
+ *
+ * Data Provider for tests in \NewspackPostImageDownloaderTest\Test_WPBlockManipulator.
+ */
+class DataProviderWPBlockManipulator {
+
+	public function get_content_with_two_image_blocks() {
+		return <<<CONTENT
+<!-- wp:image {"id":2,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://menu-live.test/wp-content/uploads/2021/10/WP-art-1-1024x439.png" alt="" class="wp-image-2"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>some text</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:image {"id":5,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://menu-live.test/wp-content/uploads/2021/10/WP-art-2-1024x341.jpg" alt="" class="wp-image-5"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph -->
+<p>some text</p>
+<!-- /wp:paragraph -->
+CONTENT;
+	}
+
+	public function get_content_with_no_blocks() {
+		return <<<CONTENT
+<!-- wp:paragraph -->
+<p>some text</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>some text</p>
+<!-- /wp:paragraph -->
+CONTENT;
+	}
+
+}

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -194,24 +194,24 @@ class Test_Downloader extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Checks that the `change_image_blocks_image` updates the Image Block's ID and src while keeping custom resolution in filename
-	 * and the query params.
+	 * Checks that the `image_block_update_image` updates the Image Block's ID, img class and src while keeping custom resolution
+	 * in filename and the query params.
 	 *
-	 * @covers \NewspackPostImageDownloader\Downloader::change_image_blocks_image
+	 * @covers \NewspackPostImageDownloader\Downloader::image_block_update_image
 	 *
 	 * @dataProvider providerImageBlockSingleWithId
 	 */
-	public function test_change_image_in_image_block_should_update_id_and_change_src_with_customizations( $block_HTML, $id, $src_original ) {
+	public function test_image_block_update_image_should_update_attachment_id_class_and_src( $block_HTML, $id, $src_original ) {
 		$downloader_partial_mock = $this->create_downloader_partial_mock_with_wp_get_attachment_url_method( $id, $src_original );
 		$new_id = 123;
 		$new_src = 'https://menu-live.test/wp-content/uploads/2021/10/WP-art-1.png';
 		$block_HTML_expected = <<<BLOCK
 <!-- wp:image {"id":123,"sizeSlug":"large","linkDestination":"none"} -->
-<figure class="wp-block-image size-large"><img src="https://menu-live.test/wp-content/uploads/2021/10/WP-art-1-1024x439.png?query=param" alt="" class="wp-image-15"/></figure>
+<figure class="wp-block-image size-large"><img src="https://menu-live.test/wp-content/uploads/2021/10/WP-art-1-1024x439.png?query=param" alt="" class="wp-image-123"/></figure>
 <!-- /wp:image -->
 BLOCK;
 
-		$block_HTML_actual = $downloader_partial_mock->change_image_blocks_image( $block_HTML, $new_id, $new_src );
+		$block_HTML_actual = $downloader_partial_mock->image_block_update_image( $block_HTML, $new_id, $new_src );
 
 		$this->assertSame( $block_HTML_expected, $block_HTML_actual );
 	}
@@ -340,7 +340,7 @@ BLOCK;
 	}
 
 	/**
-	 * DataProvider for change_image_blocks_image.
+	 * DataProvider for image_block_update_image.
 	 *
 	 * @return array[]
 	 */

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -25,12 +25,20 @@ class Test_Downloader extends WP_UnitTestCase {
 	private $downloader;
 
 	/**
+	 * WP Block manipulator dependency dummy.
+	 *
+	 * @var stdClass
+	 */
+	private $block_manipulator_dummy;
+
+	/**
 	 * Override setUp.
 	 *
 	 * @throws RuntimeException In case a temp dir could not have been created.
 	 */
 	public function setUp() {
-		$this->downloader = new Downloader();
+		$this->block_manipulator_dummy = new \stdClass();
+		$this->downloader = new Downloader( $this->block_manipulator_dummy );
 	}
 
 	/**
@@ -195,6 +203,7 @@ class Test_Downloader extends WP_UnitTestCase {
 	 */
 	private function create_downloader_partial_mock_with_file_exists_method( $local_file, $response ) {
 		$partial_mock = $this->getMockBuilder( Downloader::class )
+							 ->setConstructorArgs( [ $this->block_manipulator_dummy ] )
 							 ->setMethods( array( 'file_exists' ) )
 							 ->getMock();
 

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -7,6 +7,7 @@
 
 namespace NewspackPostImageDownloaderTest;
 
+use NewspackPostImageDownloader\WpBlockManipulator;
 use WP_UnitTestCase;
 use NewspackPostImageDownloader\Downloader;
 use RuntimeException;
@@ -25,11 +26,11 @@ class Test_Downloader extends WP_UnitTestCase {
 	private $downloader;
 
 	/**
-	 * WP Block manipulator dependency dummy.
+	 * WpBlockManipulator.
 	 *
-	 * @var stdClass
+	 * @var WpBlockManipulator
 	 */
-	private $block_manipulator_dummy;
+	private $block_manipulator;
 
 	/**
 	 * Override setUp.
@@ -37,8 +38,8 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * @throws RuntimeException In case a temp dir could not have been created.
 	 */
 	public function setUp() {
-		$this->block_manipulator_dummy = new \stdClass();
-		$this->downloader = new Downloader( $this->block_manipulator_dummy );
+		$this->block_manipulator = new WpBlockManipulator();
+		$this->downloader = new Downloader( $this->block_manipulator );
 	}
 
 	/**
@@ -193,6 +194,29 @@ class Test_Downloader extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Checks that the `change_image_blocks_image` updates the Image Block's ID and src while keeping custom resolution in filename
+	 * and the query params.
+	 *
+	 * @covers \NewspackPostImageDownloader\Downloader::change_image_blocks_image
+	 *
+	 * @dataProvider providerImageBlockSingleWithId
+	 */
+	public function test_change_image_in_image_block_should_update_id_and_change_src_with_customizations( $block_HTML, $id, $src_original ) {
+		$downloader_partial_mock = $this->create_downloader_partial_mock_with_wp_get_attachment_url_method( $id, $src_original );
+		$new_id = 123;
+		$new_src = 'https://menu-live.test/wp-content/uploads/2021/10/WP-art-1.png';
+		$block_HTML_expected = <<<BLOCK
+<!-- wp:image {"id":123,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://menu-live.test/wp-content/uploads/2021/10/WP-art-1-1024x439.png?query=param" alt="" class="wp-image-15"/></figure>
+<!-- /wp:image -->
+BLOCK;
+
+		$block_HTML_actual = $downloader_partial_mock->change_image_blocks_image( $block_HTML, $new_id, $new_src );
+
+		$this->assertSame( $block_HTML_expected, $block_HTML_actual );
+	}
+
+	/**
 	 * Creates a partial mock of the Downloader class, and mocks the `file_exists` method with expected input argument and response.
 	 * In case of a different input argument, mock will return null.
 	 *
@@ -203,7 +227,7 @@ class Test_Downloader extends WP_UnitTestCase {
 	 */
 	private function create_downloader_partial_mock_with_file_exists_method( $local_file, $response ) {
 		$partial_mock = $this->getMockBuilder( Downloader::class )
-							 ->setConstructorArgs( [ $this->block_manipulator_dummy ] )
+							 ->setConstructorArgs( [ $this->block_manipulator ] )
 							 ->setMethods( array( 'file_exists' ) )
 							 ->getMock();
 
@@ -213,6 +237,34 @@ class Test_Downloader extends WP_UnitTestCase {
 						$this->returnCallback(
 							function( $arg ) use ( $local_file, $response ) {
 								return ( $local_file === $arg ) ? $response : null;
+							}
+						)
+					);
+
+		return $partial_mock;
+	}
+
+	/**
+	 * Creates a partial mock of the Downloader class, and mocks the `wp_get_attachment_url` method.
+	 * In case of a different input argument, mock will return null.
+	 *
+	 * @param string $attachment_id Input argument for the `file_exists` method.
+	 * @param bool   $response      Expected result in case of this input argument.
+	 *
+	 * @return MockObject Partial mock.
+	 */
+	private function create_downloader_partial_mock_with_wp_get_attachment_url_method( $attachment_id, $response ) {
+		$partial_mock = $this->getMockBuilder( Downloader::class )
+							 ->setConstructorArgs( [ $this->block_manipulator ] )
+							 ->setMethods( array( 'wp_get_attachment_url' ) )
+							 ->getMock();
+
+		$partial_mock->expects( $this->any() )
+					 ->method( 'wp_get_attachment_url' )
+					->will(
+						$this->returnCallback(
+							function( $arg ) use ( $attachment_id, $response ) {
+								return ( $attachment_id === $arg ) ? $response : null;
 							}
 						)
 					);
@@ -285,5 +337,23 @@ class Test_Downloader extends WP_UnitTestCase {
 				true,
 			),
 		);
+	}
+
+	/**
+	 * DataProvider for change_image_blocks_image.
+	 *
+	 * @return array[]
+	 */
+	public function providerImageBlockSingleWithId() {
+		$block_HTML = <<<BLOCK
+<!-- wp:image {"id":15,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://menu-live.test/wp-content/uploads/2021/10/WP-art-111111-1024x439.png?query=param" alt="" class="wp-image-15"/></figure>
+<!-- /wp:image -->
+BLOCK;
+		$src_clean = 'https://menu-live.test/wp-content/uploads/2021/10/WP-art-111111.png';
+
+		return [
+			[ $block_HTML, 15, $src_clean, ]
+		];
 	}
 }

--- a/tests/unit/class-test-wpblockmanipulator.php
+++ b/tests/unit/class-test-wpblockmanipulator.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Class DownloaderTest.
+ *
+ * @package Newspack_Post_Image_Downloader
+ */
+
+namespace NewspackPostImageDownloaderTest;
+
+use WP_UnitTestCase;
+use NewspackPostImageDownloader\WpBlockManipulator;
+use RuntimeException;
+
+/**
+ * Sample test case.
+ */
+class Test_WPBlockManipulator extends WP_UnitTestCase {
+
+	/**
+	 * WpBlockManipulator object.
+	 *
+	 * @var WpBlockManipulator
+	 */
+	private $manipulator;
+
+	/**
+	 * DataProviderWPBlockManipulator object.
+	 *
+	 * @var DataProviderWPBlockManipulator
+	 */
+	private $data_provider;
+
+	/**
+	 * Override setUp.
+	 *
+	 * @throws RuntimeException In case a temp dir could not have been created.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->manipulator = new WpBlockManipulator();
+		$this->data_provider = new DataProviderWPBlockManipulator();
+	}
+
+	/**
+	 * Tests that match_wp_blocks returns the correct number of image blocks.
+	 *
+	 * @covers WpBlockManipulator::match_wp_blocks
+	 */
+	public function test_matches_blocks_multiple_images() {
+		$content = $this->data_provider->get_content_with_two_image_blocks();
+		$number_of_blocks_expected = 2;
+
+		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
+
+		$this->assertSame( $number_of_blocks_expected, count( $matches ) );
+	}
+
+	/**
+	 * Tests that match_wp_blocks doesn't find any image blocks in content where none exist.
+	 *
+	 * @covers WpBlockManipulator::match_wp_blocks
+	 */
+	public function test_matches_blocks_no_results() {
+		$content = $this->data_provider->get_content_with_no_blocks();
+
+		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
+
+		$this->assertSame( null, $matches );
+	}
+
+	/**
+	 * Tests that get_block_attribute_value returns an attribute's value.
+	 *
+	 * @covers WpBlockManipulator::get_block_attribute_value
+	 */
+	public function test_gets_block_attribute_value() {
+		$content = $this->data_provider->get_content_with_two_image_blocks();
+		$id_expected = 2;
+
+		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
+		$first_block = $matches[0][0][0];
+		$id_actual = $this->manipulator->get_block_attribute_value( $first_block, 'id' );
+
+		$this->assertSame( $id_expected, $id_actual );
+	}
+
+	/**
+	 * Tests that get_block_attribute_value doesn't return an attribute which doesn't exist.
+	 *
+	 * @covers WpBlockManipulator::get_block_attribute_value
+	 */
+	public function test_gets_block_attribute_value_attribute_not_found() {
+		$content = $this->data_provider->get_content_with_two_image_blocks();
+
+		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
+		$first_block = $matches[0][0][0];
+		$value_actual = $this->manipulator->get_block_attribute_value( $first_block, 'someRandomAttribute' );
+
+		$this->assertSame( null, $value_actual );
+	}
+
+	/**
+	 * Tests that update_block_attribute updates an existing attribute's value.
+	 *
+	 * @covers WpBlockManipulator::update_block_attribute
+	 */
+	public function test_updates_block_attribute() {
+		$content = $this->data_provider->get_content_with_two_image_blocks();
+		$value_expected = 123;
+		$first_line_expected = '<!-- wp:image {"id":' . $value_expected . ',"sizeSlug":"large","linkDestination":"none"} -->';
+
+		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
+		$first_block = $matches[0][0][0];
+		$first_block_updated = $this->manipulator->update_block_attribute( $first_block, 'id', $value_expected );
+		$first_block_updated_exploded = explode( "\n", $first_block_updated );
+		$first_line_actual = $first_block_updated_exploded[0];
+
+		$this->assertSame( $first_line_expected, $first_line_actual );
+	}
+
+	/**
+	 * Tests that update_block_attribute adds a new attribute to the block.
+	 *
+	 * @covers WpBlockManipulator::update_block_attribute
+	 */
+	public function test_adds_block_attribute() {
+		$content = $this->data_provider->get_content_with_two_image_blocks();
+		$attribute = 'customAttr';
+		$value_expected = 123;
+		$first_line_expected = '<!-- wp:image {"id":2,"sizeSlug":"large","linkDestination":"none","' . $attribute . '":' . $value_expected . '} -->';
+
+		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
+		$first_block = $matches[0][0][0];
+		$first_block_updated = $this->manipulator->update_block_attribute( $first_block, $attribute, $value_expected );
+		$first_block_updated_exploded = explode( "\n", $first_block_updated );
+		$first_line_actual = $first_block_updated_exploded[0];
+
+		$this->assertSame( $first_line_expected, $first_line_actual );
+	}
+}

--- a/tests/unit/class-test-wpblockmanipulator.php
+++ b/tests/unit/class-test-wpblockmanipulator.php
@@ -61,7 +61,7 @@ class Test_WPBlockManipulator extends WP_UnitTestCase {
 	 * @covers WpBlockManipulator::match_wp_blocks
 	 */
 	public function test_matches_blocks_no_results() {
-		$content = $this->data_provider->get_content_with_no_blocks();
+		$content = $this->data_provider->get_content_with_no_image_blocks();
 
 		$matches = $this->manipulator->match_wp_blocks( 'wp:image', $content );
 


### PR DESCRIPTION
Detect duplicate attachment images, and safely remove them by deep scanning content references and updating them too.