### PR TITLE
Non-image URL download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ Or even (temporarily) set the following constant in your `wp-config.php`
 ```php
 define( 'ALLOW_UNFILTERED_UPLOADS', true );
 ```
+
+** DISCLAIMER: This plugin destructively modifies your site's content by downloading and replacing external URLs with local media library attachments. Use this plugin at your own risk and responsibility. The authors are not responsible for any data loss, site issues, or other consequences resulting from the use of this plugin.**

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The plugin features CLI commands with parameters which offer a flexible set of b
 
 ### -- download or import images/files from local files 
 
-If you have images available in your local files, and you use the `--folder-local-images` or `--folder-local-files` parameter, the plugin will first attempt to import these directly, without downloading them.
+If you have images available in your local files, and you use the `--folder-local-files` parameter, the plugin will first attempt to import these directly, without downloading them.
 
 ### -- download images/files from specific hosts only
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Newspack Post Image Downloader
 
-This plugin is a content migration service tool. It imports externally hosted images or non-image file URLs found in your Post contents.
+This plugin imports externally hosted file URLs found in your post content. It was originally developed to a download external images, but later extended to support non-image file URLs as well.
 
-A typical use case for downloading and importing external images, is to aid migration from one host to another.
+There is also a command to list all the image or non-image URLs, so that one can examine what should be downloaded -- by specific host and extension.
 
-An optional feature is first attempting to import from a provided local folder containing the files, but if the image/file is not found it will be download from remote URL.
-
-Another functionality is listing all the image or non-image URLs in your content database. To locate the image URLs, `src`s and `srcset`s of `<img>` elements are searched. To locate non-image URLs, a hybrid approach is used to search for them: firstly various attribute URLs are searched on DOM level, then additionally HTML is searched as clear text for just additional absolute URLs.
+Optionally, one can provide a local folder containing the files. The downloader will first look for the file there, and if it's not found locally, it will be download from remote URL.
 
 The plugin presently supports three kinds of URLs:
 - absolute URLs (e.g. `https://example.com/wp-content/uploads/image.png`)
@@ -18,49 +16,53 @@ but not:
 
 ## Features
 
-The plugin features CLI commands with parameters which offer a flexible set of basic features.
-
 ### -- download or import images/files from local files 
 
-If you have images available in your local files, and you use the `--folder-local-files` parameter, the plugin will first attempt to import these directly, without downloading them.
+Optional. You can provide the path to `--folder-local-files`, and the plugin will first attempt to import files from this location, or if not found, it will download them from remote URL.
 
 ### -- download images/files from specific hosts only
 
-The plugin downloads all the externally hosted images by default. Optionally, we can set to download just from specific hosts.
+The plugin will attempt to download URLs from all external hosts. This is usually a bad thing, and one should specify and whitelist the hosts to download from by using the `--only-download-from-hosts` command parameter.
 
-There is a helper command called `scan-existing-urls` which lists all the host names used in images. After listing all existing hosts, we can chose to download just from specific ones (via the `--only-download-from-hosts` command parameter).
+Accepts wildcards, e.g. `*.example.*` to download from all Example domains, and CSV values, e.g. `*.example.com,example.com,othersite.org` to download from any of example.com subdomains, example.com (no subdomain), as well as othersite.org.
 
 ### -- skip (exclude) specific hosts from downloading
 
-Optional. Alternatively, you can specify hosts not to download images from, and the plugin will download images from all the hosts except these, e.g. `*.google.*` (the `--exclude-hosts` parameter). Wildcards are also supported to use all domain extensions and/or subdomains.
+Alternatively to whitelisting, you may blacklist hosts by using the `--exclude-hosts` parameter. 
 
-### -- skip (exclude) relative URLs from downloading
+Wildcards and CSV values are also supported here.
 
-Optional. Unless `--do-not-download-root-relative-urls` and `--do-not-download-protocol-relative-urls` flags are set, the command will automatically download relative image URLs by prepending the `--default-host-and-schema` or `https:` protocol to them.
+### -- downloads absolute and relative referenced URIs
+
+Besides downloading images from fully qualified/absolute URLs, e.g. `https://host.com/img.jpg`, the plugin can download root-relative URLs if you provide the CLI param `--default-host-and-schema=https://example-host.com` and the plugin will attempt download root-relative image URLs by prepending the `--default-host-and-schema` to them.
+
+Downloading relative URLs can be disabled by using the `--do-not-download-root-relative-urls` and `--do-not-download-protocol-relative-urls` flags.
+
+### -- scan existing URLs
+
+There is a helper command called `scan-existing-urls` which lists all the host names used in images. After listing all existing hosts, we can chose to download just from specific ones.
 
 ### -- full-size image downloading
 
-Unless the optional flag is set `--do-not-download-large-sizes`, the `download-images` command will automatically attempt to import the large-sized version of the image (non-scaled and non-intermediate).
+This plugin was made with WordPress sites in mind, and the default behavior is to import the largest available image size into the media library, and then also serve the smaller intermediate file sizes as well.
 
-This ensures that the imported Media Library attachment image is of the highest available quality. Then the smaller scaled/intermediate image also gets downloaded side-by-side to the imported larger attachment object. The effect is not seen in post_content, as the same size of image will be displayed, but the Media Library does get the highest available image quality.
+Unless the optional flag is set `--do-not-download-large-sizes`, the `download-images` command will automatically attempt to import the largest-sized version of the image it can find (non-scaled and non-intermediate).
 
-E.g.1. if an intermediate image is found in post_content for download https://www.mysite.com/wp-content/uploads/2025/01/img-puppy-300x244.jpg the command will actually import the non-intermediate image into the Media Library (without the `-300x244` suffix) https://www.mysite.com/wp-content/uploads/2025/01/img-puppy.jpg , and additionally just download the intermediate one next to it.
+For those not familiar with WordPress image sizes, see more about them in [WordPress docs](https://make.wordpress.org/core/2019/10/09/introducing-handling-of-big-images-in-wordpress-5-3/).
 
-E.g.2. or if a scaled image https://www.mysite.com/wp-content/uploads/2025/01/img-kitten-scaled.jpg is used, the command will try and import the non-scaled image https://www.mysite.com/wp-content/uploads/2025/01/img-kitten.jpg , and still seamlessly download and use the scaled version in post_content.
+E.g.1. if an intermediate image (with a size suffix appended to filename, e.g. `-300x244`) is found in post_content for download https://www.mysite.com/wp-content/uploads/2025/01/img-puppy-300x244.jpg the command will attempt to import the non-intermediate image into the Media Library https://www.mysite.com/wp-content/uploads/2025/01/img-puppy.jpg , and additionally just download the intermediate one next to it.
 
-See more about image sizes in [WordPress docs](https://make.wordpress.org/core/2019/10/09/introducing-handling-of-big-images-in-wordpress-5-3/).
+E.g.2. or if a scaled image https://www.mysite.com/wp-content/uploads/2025/01/img-kitten-scaled.jpg is used, the command will try and import the non-scaled image into the media library https://www.mysite.com/wp-content/uploads/2025/01/img-kitten.jpg , and still also seamlessly download and use the scaled version in post_content.
 
 ### -- non-image file downloading
 
-To download non-image files, a mandatory `--extensions` needs to be provided with specific extensions to download, e.g. `--extensions=pdf,docx,xlsx,pptx`.
+To download non-image files, a mandatory `--extensions` parameter is required, e.g. `--extensions=pdf,docx,xlsx,pptx`.
+
+Recommended workflow is to first run the `scan-existing-urls --include-non-image-urls` command, and then determine which extensions to download by using the `--extensions` parameter, and of course also decide which hosts to download from (using `--only-download-from-hosts` or `--exclude-hosts`).
 
 ### -- parallel downloading
 
-To speed up downloading, you could even run several commands in parallel by splitting and grouping your Post IDs into several batches, and then running the command with different `--post-id-from` and `--post-id-to` ID ranges, or with a specific `--post-ids-csv`.
-
-### -- downloads absolute or relative referenced URIs
-
-Besides downloading images from fully qualified/absolute URLs, e.g. `https://host.com/img.jpg`, the plugin can download relative URLs if you provide the CLI param `--default-host-and-schema=https://example-host.com`.
+To speed up downloading, you might want to run several download commands in parallel by splitting and grouping your Post IDs into several batches. For example, the commands can be run with different `--post-id-from` and `--post-id-to` ID ranges, or with a specific `--post-ids-csv`.
 
 ### -- custom post type and post status selection
 
@@ -72,7 +74,7 @@ You can specify a list of Post IDs by using the `--post-ids-csv` or an ID range 
 
 ### -- error logging
 
-Creates detailed custom error logs for review afterwards.
+Creates detailed error logs for review afterwards.
 
 ### -- dry-run
 
@@ -82,7 +84,7 @@ You may simulate and run the command without actual downloads or changes to your
 
 Run `composer install`.
 
-## List of all available commands and parameters.
+## List of all the available commands and parameters.
 
 Can be found [here](https://github.com/Automattic/newspack-post-image-downloader/blob/master/src/class-downloader.php#L39).
 
@@ -100,4 +102,6 @@ Or even (temporarily) set the following constant in your `wp-config.php`
 define( 'ALLOW_UNFILTERED_UPLOADS', true );
 ```
 
-** DISCLAIMER: This plugin destructively modifies your site's content by downloading and replacing external URLs from the post content with local media library attachments. Use this plugin at your own risk and responsibility. The authors are not responsible for any data loss, site issues, or other consequences resulting from the use of this plugin.**
+## DISCLAIMER
+
+**This plugin destructively modifies your site's content by downloading and replacing external URLs from the post content with local media library attachments. Use this plugin at your own risk and responsibility. The authors are not responsible for any data loss, site issues, or other consequences resulting from the use of this plugin.**

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 # Newspack Post Image Downloader
 
-This plugin is a content migration service tool. It imports externally hosted images found in your Post contents.
+This plugin is a content migration service tool. It imports externally hosted images or non-image file URLs found in your Post contents.
 
-A typical use case for downloading and importing external images, is to aid importing of all the contents after the site's migration from one host to another.
+A typical use case for downloading and importing external images, is to aid migration from one host to another.
 
-The plugin can first attempt to import the images from local files, if you have them available as local files, or if not, it will download and import them from the source URL.
+An optional feature is first attempting to import from a provided local folder containing the files, but if the image/file is not found it will be download from remote URL.
+
+Another functionality is listing all the image or non-image URLs in your content database. To locate the image URLs, `src`s and `srcset`s of `<img>` elements are searched. To locate non-image URLs, a hybrid approach is used to search for them: firstly various attribute URLs are searched on DOM level, then additionally HTML is searched as clear text for just additional absolute URLs.
+
+The plugin presently supports three kinds of URLs:
+- absolute URLs (e.g. `https://example.com/wp-content/uploads/image.png`)
+- root-relative URLs (e.g. `/wp-content/uploads/image.png`)
+- protocol-relative URLs (e.g. `//example.com/path`)
+but not:
+- page-relative (e.g. `../uploads/image.png`)
+
 
 ## Features
 
 The plugin features CLI commands with parameters which offer a flexible set of basic features.
 
-### -- download or import images from local files 
+### -- download or import images/files from local files 
 
-If you have images available in your local files, and you use the `--folder-local-images` parameter, the plugin will first attempt to import these directly, without downloading them.
+If you have images available in your local files, and you use the `--folder-local-images` or `--folder-local-files` parameter, the plugin will first attempt to import these directly, without downloading them.
 
-### -- download images from specific hosts only
+### -- download images/files from specific hosts only
 
 The plugin downloads all the externally hosted images by default. Optionally, we can set to download just from specific hosts.
 
-There is a helper command called `scan-existing-images-hostnames` which lists all the host names used in images. After listing all existing hosts, we can chose to download just from specific ones (via the `--only-download-from-hosts` command parameter).
+There is a helper command called `scan-existing-urls` which lists all the host names used in images. After listing all existing hosts, we can chose to download just from specific ones (via the `--only-download-from-hosts` command parameter).
 
 ### -- skip (exclude) specific hosts from downloading
 
@@ -26,11 +36,11 @@ Optional. Alternatively, you can specify hosts not to download images from, and 
 
 ### -- skip (exclude) relative URLs from downloading
 
-Optional. Unless `--do-not-download-relative-urls` flag is set, the command will automatically download relative image URLs by prepending the `--default-image-host-and-schema` to them.
+Optional. Unless `--do-not-download-root-relative-urls` and `--do-not-download-protocol-relative-urls` flags are set, the command will automatically download relative image URLs by prepending the `--default-image-host-and-schema` or `https:` protocol to them.
 
 ### -- full-size image downloading
 
-Unless the optional flag is set `--do-not-download-large-sizes`, the `import-images` command will automatically attempt to import the large-sized version of the image (non-scaled and non-intermediate).
+Unless the optional flag is set `--do-not-download-large-sizes`, the `download-images` command will automatically attempt to import the large-sized version of the image (non-scaled and non-intermediate).
 
 This ensures that the imported Media Library attachment image is of the highest available quality. Then the smaller scaled/intermediate image also gets downloaded side-by-side to the imported larger attachment object. The effect is not seen in post_content, as the same size of image will be displayed, but the Media Library does get the highest available image quality.
 
@@ -39,6 +49,10 @@ E.g.1. if an intermediate image is found in post_content for download https://ww
 E.g.2. or if a scaled image https://www.mysite.com/wp-content/uploads/2025/01/img-kitten-scaled.jpg is used, the command will try and import the non-scaled image https://www.mysite.com/wp-content/uploads/2025/01/img-kitten.jpg , and still seamlessly download and use the scaled version in post_content.
 
 See more about image sizes in [WordPress docs](https://make.wordpress.org/core/2019/10/09/introducing-handling-of-big-images-in-wordpress-5-3/).
+
+### -- non-image file downloading
+
+To download non-image files, a mandatory `--extensions` needs to be provided with specific extensions to download, e.g. `--extensions=pdf,docx,xlsx,pptx`.
 
 ### -- parallel downloading
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Optional. Alternatively, you can specify hosts not to download images from, and 
 
 ### -- skip (exclude) relative URLs from downloading
 
-Optional. Unless `--do-not-download-root-relative-urls` and `--do-not-download-protocol-relative-urls` flags are set, the command will automatically download relative image URLs by prepending the `--default-image-host-and-schema` or `https:` protocol to them.
+Optional. Unless `--do-not-download-root-relative-urls` and `--do-not-download-protocol-relative-urls` flags are set, the command will automatically download relative image URLs by prepending the `--default-host-and-schema` or `https:` protocol to them.
 
 ### -- full-size image downloading
 
@@ -60,7 +60,7 @@ To speed up downloading, you could even run several commands in parallel by spli
 
 ### -- downloads absolute or relative referenced URIs
 
-Besides downloading images from fully qualified/absolute URLs, e.g. `https://host.com/img.jpg`, the plugin can download relative URLs if you provide the CLI param `--default-image-host-and-schema=https://example-host.com`.
+Besides downloading images from fully qualified/absolute URLs, e.g. `https://host.com/img.jpg`, the plugin can download relative URLs if you provide the CLI param `--default-host-and-schema=https://example-host.com`.
 
 ### -- custom post type and post status selection
 
@@ -100,4 +100,4 @@ Or even (temporarily) set the following constant in your `wp-config.php`
 define( 'ALLOW_UNFILTERED_UPLOADS', true );
 ```
 
-** DISCLAIMER: This plugin destructively modifies your site's content by downloading and replacing external URLs with local media library attachments. Use this plugin at your own risk and responsibility. The authors are not responsible for any data loss, site issues, or other consequences resulting from the use of this plugin.**
+** DISCLAIMER: This plugin destructively modifies your site's content by downloading and replacing external URLs from the post content with local media library attachments. Use this plugin at your own risk and responsibility. The authors are not responsible for any data loss, site issues, or other consequences resulting from the use of this plugin.**

--- a/composer.lock
+++ b/composer.lock
@@ -12,17 +12,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/newspack-migration-tools.git",
-                "reference": "2998c4b39c09eca07b52b25bde03b4b66aae6f3c"
+                "reference": "2194daf185c4701d907b708296be62543da998c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/2998c4b39c09eca07b52b25bde03b4b66aae6f3c",
-                "reference": "2998c4b39c09eca07b52b25bde03b4b66aae6f3c",
+                "url": "https://api.github.com/repos/Automattic/newspack-migration-tools/zipball/2194daf185c4701d907b708296be62543da998c1",
+                "reference": "2194daf185c4701d907b708296be62543da998c1",
                 "shasum": ""
             },
             "require": {
                 "bramus/monolog-colored-line-formatter": "^3.1",
-                "halaxa/json-machine": "^1.1",
+                "halaxa/json-machine": "^1.1.5",
                 "monolog/monolog": "^3.7",
                 "php": ">=8.1"
             },
@@ -71,7 +71,7 @@
                 "source": "https://github.com/Automattic/newspack-migration-tools/tree/trunk",
                 "issues": "https://github.com/Automattic/newspack-migration-tools/issues"
             },
-            "time": "2025-07-29T14:36:45+00:00"
+            "time": "2025-08-08T08:59:49+00:00"
         },
         {
             "name": "brainmaestro/composer-git-hooks",

--- a/newspack-post-image-downloader.php
+++ b/newspack-post-image-downloader.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.pub/
  * Author:      Automattic
  * Author URI:  https://newspack.pub/
- * Version:     1.2.2
+ * Version:     1.3.0
  *
  * @package  Newspack_Post_Image_Downloader
  */

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -87,28 +87,29 @@ class Downloader {
 	 */
 	public function register_commands() {
 		WP_CLI::add_command(
-			'newspack-post-image-downloader scan-existing-images-hostnames',
-			[ $this, 'cmd_scan_existing_images_hostnames' ],
+			'newspack-post-image-downloader scan-existing-urls',
+			[ $this, 'cmd_scan_existing_urls' ],
 			[
-				'shortdesc' => 'Helper command. Goes through all the Posts and Pages, and searches for all existing images\' hostnames (useful to ascertain a list of hostnames to exclude from downloading).',
+				'shortdesc' => 'Searches all existing image URLs in <img src> attributes in posts and pages, and lists hostnames and extensions. Useful to ascertain existing hostnames to include/exclude from downloading.',
 				[
 					[
 						'type'        => 'flag',
-						'name'        => 'list-all-post-ids',
-						'description' => 'Besides listing the results with all the images `src` hostnames found in your Posts, also list all the Post IDs where these were found.',
+						'name'        => 'include-non-image-urls',
+						'description' => 'By default, only scans image URLs, but if this flag is set, it will also scan non-image URLs.',
 						'optional'    => true,
+						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-types',
-						'description' => 'Optional CSV Post types. Defaults are `post,page`',
+						'description' => 'Optional CSV Post types to scan. Defaults are `post,page`',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-statuses',
-						'description' => 'Optional CSV Post statuses. Defaults is `publish`',
+						'description' => 'Optional CSV Post statuses to scan. Defaults is `publish`',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -137,52 +138,8 @@ class Downloader {
 			]
 		);
 		WP_CLI::add_command(
-			'newspack-post-image-downloader list-all-urls',
-			[ $this, 'cmd_list_all_urls' ],
-			[
-				'shortdesc' => 'Helper command. This one generates a more comprehensive list of all the URLs used on the site. It scans HTML contents for any `href` and `src` attributes—covering links, scripts, images, other media types, and more — but ignores plain-text URLs. All extracted URLs are saved to a log file for a custom review.',
-				'synopsis'  => [
-					[
-						'type'        => 'assoc',
-						'name'        => 'post-types',
-						'description' => 'Optional CSV Post types. Defaults are `post,page`',
-						'optional'    => true,
-						'repeating'   => false,
-					],
-					[
-						'type'        => 'assoc',
-						'name'        => 'post-statuses',
-						'description' => 'Optional CSV Post statuses. Defaults is `publish`',
-						'optional'    => true,
-						'repeating'   => false,
-					],
-					[
-						'type'        => 'assoc',
-						'name'        => 'post-ids-csv',
-						'description' => 'Specify Posts to scan with a CSV list of Post IDs.',
-						'optional'    => true,
-						'repeating'   => false,
-					],
-					[
-						'type'        => 'assoc',
-						'name'        => 'post-id-from',
-						'description' => 'Specify Post IDs to scan with a from-to range.',
-						'optional'    => true,
-						'repeating'   => false,
-					],
-					[
-						'type'        => 'assoc',
-						'name'        => 'post-id-to',
-						'description' => 'Specify Post IDs to scan with a from-to range.',
-						'optional'    => true,
-						'repeating'   => false,
-					],
-				],
-			]
-		);
-		WP_CLI::add_command(
-			'newspack-post-image-downloader import-images',
-			[ $this, 'cmd_import_images' ],
+			'newspack-post-image-downloader download-images',
+			[ $this, 'cmd_download_images' ],
 			[
 				'shortdesc' => 'Downloads all remote images to local.',
 				'synopsis'  => [
@@ -208,8 +165,15 @@ class Downloader {
 					],
 					[
 						'type'        => 'flag',
-						'name'        => 'do-not-download-relative-urls',
-						'description' => 'Unless this flag is set, the command will automatically download relative image URLs by prepending the --default-image-host-and-schema to them.',
+						'name'        => 'do-not-download-root-relative-urls',
+						'description' => 'Unless this flag is set, the command will automatically download root-relative image URLs (e.g. `/wp-content/uploads/image.jpg`) by prepending the --default-image-host-and-schema to them.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'do-not-download-protocol-relative-urls',
+						'description' => 'Unless this flag is set, the command will automatically download protocol-relative image URLs (e.g. `//cdn.host.com/img.jpg`) by prepending https: to them.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -237,35 +201,35 @@ class Downloader {
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-types',
-						'description' => 'Optional CSV Post types. Defaults are `post,page`',
+						'description' => 'Optional CSV Post types to download images from. Defaults are `post,page`',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-statuses',
-						'description' => 'Optional CSV Post statuses. Defaults is `publish`',
+						'description' => 'Optional CSV Post statuses to download images from. Defaults is `publish`',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-ids-csv',
-						'description' => 'CSV list of Post IDs.',
+						'description' => 'CSV list of Post IDs to download images from.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-id-from',
-						'description' => 'Only scan Post IDs from-to.',
+						'description' => 'Only download images from Post IDs from-to.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-id-to',
-						'description' => 'Only scan Post IDs from-to.',
+						'description' => 'Only download images from Post IDs from-to.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -273,8 +237,8 @@ class Downloader {
 			]
 		);
 		WP_CLI::add_command(
-			'newspack-post-image-downloader import-non-images-files',
-			[ $this, 'cmd_import_non_images_files' ],
+			'newspack-post-image-downloader download-non-images-files',
+			[ $this, 'cmd_download_non_images_files' ],
 			[
 				'shortdesc' => 'Downloads other non-image files to local.',
 				'synopsis'  => [
@@ -294,14 +258,21 @@ class Downloader {
 					[
 						'type'        => 'assoc',
 						'name'        => 'extensions',
-						'description' => 'CSV list of extensions to download. E.g. --extensions=pdf,docx,xlsx,pptx',
+						'description' => 'Extensions to download. E.g. --extensions=pdf,docx,xlsx,pptx',
 						'optional'    => false,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'flag',
-						'name'        => 'do-not-download-relative-urls',
-						'description' => 'Unless this flag is set, the command will automatically download relative image URLs by prepending the --default-image-host-and-schema to them.',
+						'name'        => 'do-not-download-root-relative-urls',
+						'description' => 'Unless this flag is set, the command will automatically download root-relative image URLs (e.g. `/wp-content/uploads/image.jpg`) by prepending the --default-image-host-and-schema to them.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'do-not-download-protocol-relative-urls',
+						'description' => 'Unless this flag is set, the command will automatically download protocol-relative image URLs (e.g. `//cdn.host.com/img.jpg`) by prepending https: to them.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -329,35 +300,35 @@ class Downloader {
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-types',
-						'description' => 'Optional CSV Post types. Defaults are `post,page`',
+						'description' => 'Optional CSV Post types to download files from. Defaults are `post,page`',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-statuses',
-						'description' => 'Optional CSV Post statuses. Defaults is `publish`',
+						'description' => 'Optional CSV Post statuses to download files from. Defaults is `publish`',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-ids-csv',
-						'description' => 'CSV list of Post IDs.',
+						'description' => 'CSV list of Post IDs to download files from.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-id-from',
-						'description' => 'Only scan Post IDs from-to.',
+						'description' => 'Only download files from Post IDs from-to.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'post-id-to',
-						'description' => 'Only scan Post IDs from-to.',
+						'description' => 'Only download files from Post IDs from-to.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -367,20 +338,21 @@ class Downloader {
 	}
 
 	/**
-	 * Callable for `newspack-post-image-downloader scan-existing-images-hostnames`.
+	 * Callable for `newspack-post-image-downloader scan-existing-urls`.
 	 * See command description in \NewspackPostImageDownloader\Downloader::register_commands.
 	 *
-	 * @param array $args       CLI arguments.
+	 * @param array $pos_args   CLI arguments.
 	 * @param array $assoc_args CLI associative arguments.
 	 */
-	public function cmd_scan_existing_images_hostnames( $args, $assoc_args ) {
-		$list_all_post_ids = isset( $assoc_args['list-all-post-ids'] );
-		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
-		$post_statuses     = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
-		$post_ids_specific = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
-		$post_id_from      = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
-		$post_id_to        = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
+	public function cmd_scan_existing_urls( $pos_args, $assoc_args ) {
+		$include_non_image_urls = isset( $assoc_args['include-non-image-urls'] ) ? true : false;
+		$post_types             = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
+		$post_statuses          = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
+		$post_ids_specific      = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
+		$post_id_from           = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
+		$post_id_to             = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
 
+		$time_start = microtime( true );
 		$this->init_loggers( __FUNCTION__ );
 		if ( ( $post_ids_specific && $post_id_from ) || ( $post_ids_specific && $post_id_to ) ) {
 			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Sorry, you can either specify a CSV list of Post IDs, or a range of Post IDs.' );
@@ -390,88 +362,31 @@ class Downloader {
 			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Both --post-id-from and --post-id-to are required when using ranges.' );
 			exit;
 		}
-
-		$time_start = microtime( true );
-		$post_ids   = $this->get_post_ids( $post_ids_specific, $post_id_from, $post_id_to, $post_types, $post_statuses );
-		if ( empty( $post_ids ) ) {
-			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::WARNING, 'No Posts found... 🤔' );
-			exit;
-		}
-		MemoryCleanupHook::cleanup();
-
-		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( 'Checking image hosts in %d posts...', count( $post_ids ) ) );
-		$img_hostnames_post_ids = [];
-		foreach ( $post_ids as $key_post_id => $post_id ) {
-			MemoryCleanupHook::cleanup( 0, $key_post_id, 50 );
-
-			$post_content = $this->get_post_content( $post_id );
-			if ( ! $post_content ) {
-				$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::WARNING, sprintf( '⚠️ Could not fetch content for post ID %d', $post_id ) );
-				continue;
-			}
-			$post_img_hostnames = $this->get_all_image_hostnames_from_post_content( $post_content );
-
-			// Add the post ID to the list of post IDs for each image hostname.
-			foreach ( $post_img_hostnames as $img_hostname ) {
-				$img_hostnames_post_ids[ $img_hostname ][] = $post_id;
-			}
-		}
-
-		// Tada!
-		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total image hosts%s', count( $img_hostnames_post_ids ), ( count( $img_hostnames_post_ids ) > 0 ? ':' : '.' ) ) );
-		if ( count( $img_hostnames_post_ids ) ) {
-			foreach ( $img_hostnames_post_ids as $img_hostname => $post_ids ) {
-				$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( '- %s%s', $img_hostname, $list_all_post_ids ? ' -- in post IDs: ' . implode( ',', $post_ids ) : '' ) );
-			}
-		}
-
-		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'Done in %d mins! 🙌 ', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
-	}
-
-	/**
-	 * Callable for `newspack-post-image-downloader list-all-urls`.
-	 * See command description in \NewspackPostImageDownloader\Downloader::register_commands.
-	 *
-	 * @param array $args        CLI arguments.
-	 * @param array $assoc_args  CLI associative arguments.
-	 */
-	public function cmd_list_all_urls( $args, $assoc_args ) {
-		$post_types        = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
-		$post_statuses     = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
-		$post_ids_specific = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
-		$post_id_from      = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
-		$post_id_to        = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
-
-		$this->init_loggers( __FUNCTION__ );
-		if ( ( $post_ids_specific && $post_id_from ) || ( $post_ids_specific && $post_id_to ) ) {
-			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Sorry, you can either specify a CSV list of Post IDs, or a range of Post IDs.' );
-			exit;
-		}
-		if ( ( $post_id_from && ( null === $post_id_to ) ) || ( ( null === $post_id_from ) && $post_id_to ) ) {
-			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Both --post-id-from and --post-id-to are required when using ranges.' );
-			exit;
-		}
-
-		$time_start = microtime( true );
 		
-		// Prepare the log file.
-		$log_file = 'urls_in_posts.csv';
-		if ( $this->file_exists( $log_file ) ) {
-			unlink( $log_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
+		// Prepare the CSV file.
+		$csv_file = __FUNCTION__ . '__urls' . ( $include_non_image_urls ? '_all' : '_images' ) . '.csv';
+		if ( $this->file_exists( $csv_file ) ) {
+			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
 		}
-		$log_file_handle = fopen( $log_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
-		fputcsv( $log_file_handle, [ 'post_id', 'url' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+		$csv_file_handle = fopen( $csv_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
+		fputcsv( $csv_file_handle, [ 'post_id', 'hostname', 'extension', 'url' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
+		// Get post IDs.
 		$post_ids = $this->get_post_ids( $post_ids_specific, $post_id_from, $post_id_to, $post_types, $post_statuses );
 		if ( empty( $post_ids ) ) {
-			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::WARNING, 'No Posts found... 🤔' );
+			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::WARNING, 'No Posts found... 🤔' );
 			exit;
 		}
 		MemoryCleanupHook::cleanup();
 
-		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( 'Getting all URLs from %d posts...', count( $post_ids ) ) );
+		// Scan posts.
+		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( 'Getting %s URLs from %d posts...', $include_non_image_urls ? 'all' : 'image', count( $post_ids ) ) );
+		$cli_quick_output = [
+			'hostnames'  => [],
+			'extensions' => [],
+		];
 		foreach ( $post_ids as $key_post_id => $post_id ) {
-			MemoryCleanupHook::cleanup( 0, $key_post_id, 50 );
+			MemoryCleanupHook::cleanup( 0, $key_post_id + 1, 10 );
 
 			$post_content = $this->get_post_content( $post_id );
 			if ( ! $post_content ) {
@@ -479,42 +394,90 @@ class Downloader {
 				continue;
 			}
 
-			$urls = $this->get_all_urls( $post_content );
+			// Get all URLs, or just image `src`s.
+			$urls = $include_non_image_urls
+				? $this->get_all_urls( $post_content )
+				: $this->get_all_img_srcs( $post_content );
 			if ( empty( $urls ) ) {
 				continue;
 			}
-
 			foreach ( $urls as $url ) {
-				fputcsv( $log_file_handle, [ $post_id, $url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+				// Validate URL.
+				$is_absolute          = $this->is_url_absolute( $url );
+				$is_root_relative     = $this->is_url_root_relative( $url );
+				$is_protocol_relative = $this->is_url_protocol_relative( $url );
+				if ( ! $this->is_url_valid( $url ) ) {
+					continue;
+				}
+
+				// Get hostname and extension.
+				$url_check = null;
+				if ( $is_absolute || $is_root_relative ) {
+					$url_check = $url;
+				} elseif ( $is_protocol_relative ) {
+					$url_check = 'https:' . $url;
+				} else {
+					// Unsupported URL, like `src="data:image/svg+xml;base64"` or invalid URLs.
+					fputcsv( $csv_file_handle, [ $post_id, 'N/A', 'N/A', $url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+					continue;
+				}
+
+				// Get hostname.
+				$parsed   = wp_parse_url( $url_check );
+				$hostname = $parsed['host'] ?? null;
+
+				// Get extension.
+				$extension = $this->get_url_extension( $url_check );
+
+				// Add to CSV.
+				fputcsv( $csv_file_handle, [ $post_id, ! empty( $hostname ) ? $hostname : 'N/A', ! empty( $extension ) ? $extension : 'NO_EXTENSION', $url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+
+				// Add to quick CLI output variable.
+				if ( ! empty( $hostname ) && ! in_array( $hostname, $cli_quick_output['hostnames'] ) ) {
+					$cli_quick_output['hostnames'][] = $hostname;
+				}
+				if ( ! empty( $extension ) && ! in_array( $extension, $cli_quick_output['extensions'] ) ) {
+					$cli_quick_output['extensions'][] = $extension;
+				}
 			}
 		}
 
-		fclose( $log_file_handle );
+		fclose( $csv_file_handle );
 
 		// Tada!
-		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'Done in %d mins! See %s for list of URLs. 🙌 ', floor( ( microtime( true ) - $time_start ) / 60 ), $log_file ) );
+		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total URL hosts', count( $cli_quick_output['hostnames'] ) ) );
+		if ( count( $cli_quick_output['hostnames'] ) > 0 ) {
+			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '- %s', implode( "\n- ", $cli_quick_output['hostnames'] ) ) );
+		}
+		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total URL extensions', count( $cli_quick_output['extensions'] ) ) );
+		if ( count( $cli_quick_output['extensions'] ) > 0 ) {
+			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '- %s', implode( ', ', $cli_quick_output['extensions'] ) ) );
+		}
+		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( 'Done in %d mins! 🙌 ', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
+		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 See CSV file for full list of post IDs, URLs, hostnames and extensions: %s ', $csv_file ) );
 	}
 
 	/**
 	 * Callable for `newspack-post-image-downloader import-images`.
 	 * See command description in \NewspackPostImageDownloader\Downloader::register_commands.
 	 *
-	 * @param array $args       CLI arguments.
+	 * @param array $pos_args   CLI arguments.
 	 * @param array $assoc_args CLI associative arguments.
 	 */
-	public function cmd_import_images( $args, $assoc_args ) {
-		$dry_run                       = isset( $assoc_args['dry-run'] ) ? true : false;
-		$do_not_download_large_sizes   = isset( $assoc_args['do-not-download-large-sizes'] ) ? true : false;
-		$do_not_download_relative_urls = isset( $assoc_args['do-not-download-relative-urls'] ) ? true : false;
-		$post_types                    = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
-		$post_statuses                 = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
-		$post_ids_specific             = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
-		$post_id_from                  = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
-		$post_id_to                    = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
-		$hosts_excluded                = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
-		$only_download_from_hosts      = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
-		$default_image_host_and_schema = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
-		$folder_local_images           = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
+	public function cmd_download_images( $pos_args, $assoc_args ) {
+		$dry_run                                = isset( $assoc_args['dry-run'] ) ? true : false;
+		$do_not_download_large_sizes            = isset( $assoc_args['do-not-download-large-sizes'] ) ? true : false;
+		$do_not_download_root_relative_urls     = isset( $assoc_args['do-not-download-root-relative-urls'] ) ? true : false;
+		$do_not_download_protocol_relative_urls = isset( $assoc_args['do-not-download-protocol-relative-urls'] ) ? true : false;
+		$post_types                             = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
+		$post_statuses                          = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
+		$post_ids_specific                      = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
+		$post_id_from                           = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
+		$post_id_to                             = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
+		$hosts_excluded                         = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
+		$only_download_from_hosts               = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
+		$default_image_host_and_schema          = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
+		$folder_local_images                    = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
 
 		$this->init_loggers( __FUNCTION__ );
 		if ( ( $post_ids_specific && $post_id_from ) || ( $post_ids_specific && $post_id_to ) ) {
@@ -529,6 +492,14 @@ class Downloader {
 			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When providing the `--only-download-from-hosts` param, do not use the `--exclude-hosts` at the same time.' );
 			exit;
 		}
+
+		// Prepare the CSV file.
+		$csv_file = __FUNCTION__ . '__downloaded.csv';
+		if ( $this->file_exists( $csv_file ) ) {
+			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
+		}
+		$csv_file_handle = fopen( $csv_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
+		fputcsv( $csv_file_handle, [ 'post_id', 'url_original', 'attachment_id', 'url_downloaded' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 		global $wpdb;
 		$time_start        = microtime( true );
@@ -550,7 +521,7 @@ class Downloader {
 				continue;
 			}
 
-			MemoryCleanupHook::cleanup( 0, $key_post, 50 );
+			MemoryCleanupHook::cleanup( 0, $key_post + 1, 10 );
 
 			// Extract attributes from all the `<img>`s.
 			$img_data = ( new Crawler( $post_content ) )->filterXpath( '//img' )->extract( [ 'src', 'title', 'alt' ] );
@@ -587,23 +558,29 @@ class Downloader {
 				$alt                  = trim( $img_datum['alt'] );
 
 				// Boolean flags for simpler logic.
-				$is_scaled       = ! empty( $src_non_scaled );
-				$is_intermediate = ! empty( $src_non_intermediate );
-				$is_relative     = 0 === strpos( $src, '/' );
-				$is_absolute     = 0 === strpos( strtolower( $src ), 'http' );
+				$is_scaled            = ! empty( $src_non_scaled );
+				$is_intermediate      = ! empty( $src_non_intermediate );
+				$is_root_relative     = $this->is_url_root_relative( $src );
+				$is_protocol_relative = $this->is_url_protocol_relative( $src );
+				$is_absolute          = $this->is_url_absolute( $src );
 
-				// Basic URL validation -- either relative, or absolute and valid.
-				$is_url_valid = $is_relative || ( $is_absolute && filter_var( $src, FILTER_VALIDATE_URL ) );
-				if ( ! $is_url_valid ) {
+				// Validate URL.
+				if ( ! $this->is_url_valid( $src ) ) {
 					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Invalid URL type '%s'", $src ), [ 'post_id' => $post_id ] );
 					continue;
 				}
 
-				// Skip relative URLs if the flag is set.
-				if ( $is_relative && $do_not_download_relative_urls ) {
-					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, relative URL '%s'", $src ), [ 'post_id' => $post_id ] );
+				// Skip root-relative URLs if the flag is set.
+				if ( $is_root_relative && $do_not_download_root_relative_urls ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, root-relative URL '%s'", $src ), [ 'post_id' => $post_id ] );
 					continue;
 				}
+				// Skip protocol-relative URLs if the flag is set.
+				if ( $is_protocol_relative && $do_not_download_protocol_relative_urls ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, protocol-relative URL '%s'", $src ), [ 'post_id' => $post_id ] );
+					continue;
+				}
+				
 				// Skip if $src was already used/downloaded and replaced.
 				if ( false === strpos( $post_content_updated, $src ) && false === strpos( $post_content_updated, esc_attr( $src ) ) ) {
 					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, src already downloaded '%s'", $src ), [ 'post_id' => $post_id ] );
@@ -613,8 +590,12 @@ class Downloader {
 				// Filter `src` by host.
 				if ( $only_download_from_hosts ) {
 					// Skip if relative URL host (--default-image-host-and-schema) does not match $only_download_from_hosts.
-					if ( $is_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
-						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping relative URL, off target host '%s'", $src ), [ 'post_id' => $post_id ] );
+					if ( $is_root_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, off target host '%s'", $src ), [ 'post_id' => $post_id ] );
+						continue;
+					} elseif ( $is_protocol_relative && ! $this->does_uri_match_host( 'https:' . $src, $only_download_from_hosts ) ) {
+						// Skip if protocol-relative URL host does not match $only_download_from_hosts.
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping protocol-relative URL, off target host '%s'", $src ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_absolute && ! $this->does_uri_match_host( $src, $only_download_from_hosts ) ) {
 						// Skip if absolute URL host does not match $only_download_from_hosts.
@@ -623,8 +604,12 @@ class Downloader {
 					}
 				} elseif ( $hosts_excluded ) {
 					// Skip if relative URL host matches $hosts_excluded.
-					if ( $is_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
-						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping relative URL, excluded host '%s'", $src ), [ 'post_id' => $post_id ] );
+					if ( $is_root_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, excluded host '%s'", $src ), [ 'post_id' => $post_id ] );
+						continue;
+					} elseif ( $is_protocol_relative && $this->does_uri_match_host( 'https:' . $src, $hosts_excluded ) ) {
+						// Skip if protocol-relative URL host matches $hosts_excluded.
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping protocol-relative URL, excluded host '%s'", $src ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_absolute && $this->does_uri_match_host( $src, $hosts_excluded ) ) {
 						// Skip if absolute URL host matches $hosts_excluded.
@@ -694,6 +679,9 @@ class Downloader {
 						if ( ! $dry_run ) {
 							$attachment_id = $attachments_logic->import_external_file( $img_import_path, $title_to_use, null, null, $alt_to_use, $post_id );
 							if ( is_wp_error( $attachment_id ) ) {
+								// CSV, log error.
+								fputcsv( $csv_file_handle, [ $post_id, $src_ranked, sprintf( 'ERROR: %s', $attachment_id->get_error_message() ), '' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+
 								$this->log(
 									self::LOG_OUTPUTS['CLI_AND_FILE'],
 									LogLevel::ERROR,
@@ -715,15 +703,21 @@ class Downloader {
 									'src'     => $src_ranked,
 								] 
 							);
-							
+
+							// Imported attachment URL.
+							$attachment_url = wp_get_attachment_url( $attachment_id );
+
 							// Get the target directory where the attachment was saved.
 							$target_path     = get_attached_file( $attachment_id );
 							$imported_folder = dirname( $target_path );
-							
+
 							// If this is the $src, note new the new URL.
 							if ( $src == $src_ranked ) {
-								$src_local = wp_get_attachment_url( $attachment_id );
+								$src_local = $attachment_url;
 							}
+
+							// CSV, add the imported image to the CSV file.
+							fputcsv( $csv_file_handle, [ $post_id, $src_ranked, $attachment_id, $attachment_url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 						} else {
 							// Dry run.
 							$imported        = true;
@@ -769,6 +763,9 @@ class Downloader {
 							$downloaded = $this->download_file_to_dir( $src_ranked, $target_path );
 							// Handle error.
 							if ( is_wp_error( $downloaded ) ) {
+								// CSV, log error.
+								fputcsv( $csv_file_handle, [ $post_id, $src_ranked, sprintf( 'ERROR: %s', $downloaded->get_error_message() ), '' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+
 								$this->log(
 									self::LOG_OUTPUTS['CLI_AND_FILE'],
 									LogLevel::ERROR,
@@ -781,12 +778,17 @@ class Downloader {
 								continue;
 							}
 
-							// If this is the $src, and it has been downloaded, note new the new local URL.
+							// Downloaded URL.
+							$downloaded_url = dirname( wp_get_attachment_url( $attachment_id ) ) . '/' . basename( $src );
+
+							// If this is the $src, and it has been downloaded, note new the new local URL (same folder/URL path as imported $attachment_id, i.e. $src's filename).
 							if ( $src == $src_ranked ) {
-								// Same folder (URL path) as imported $attachment_id, with $src's filename.
-								$src_local = dirname( wp_get_attachment_url( $attachment_id ) ) . '/' . basename( $src );
+								$src_local = $downloaded_url;
 							}
 							
+							// CSV, add the imported image to the CSV file.
+							fputcsv( $csv_file_handle, [ $post_id, $src_ranked, '', $downloaded_url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+
 							$this->log(
 								self::LOG_OUTPUTS['CLI_AND_FILE'],
 								LogLevel::INFO,
@@ -848,91 +850,37 @@ class Downloader {
 			}
 		}
 
+		fclose( $csv_file_handle );
+
 		// Required for the $wpdb->update() to sink in.
 		wp_cache_flush();
 
 		// Closing remarks.
 		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'All done!  🙌  Took %d mins.', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
-	}
-
-	/**
-	 * Extracts all absolute and relative URLs from a HTML content.
-	 * Searches in HTML as a string, and not as a DOM.
-	 *
-	 * @param string $html HTML content.
-	 * @return array Array of matched URLs.
-	 */
-	public function get_urls_from_html( string $html ): array {
-	
-		/**
-		 * (?<=[\'"\s\n\r\t])           = Ensure the match is *preceded* by a quote (' or "), whitespace, newline, carriage return, or tab
-		 *                                to increase likelihood it's part of an HTML attribute or text content.
-		 * (                            = Start of main capture group:
-		 *   https?://[^\s"\'>\n\r\t]+  = Match http or https absolute URLs (non-greedy up to next space, quote, angle bracket, or line break).
-		 *   |                          = OR
-		 *   /[^\s"\'>\n\r\t]+          = Match relative URLs that start with a forward slash.
-		 * )                            = End of capture group.
-		 * #i                           = Case-insensitive delimiter.
-		 */
-		$pattern = '#(?<=[\'"\s\n\r\t])(https?://[^\s"\'>\n\r\t]+|/[^\s"\'>\n\r\t]+)#i';
-		preg_match_all( $pattern, $html, $matches );
-	
-		// Unique URLs.
-		$urls = array_unique( $matches[0] );
-
-		return $urls;
-	}
-
-	/**
-	 * Gets the extension of a URL path segment (i.e. the URLs file extension).
-	 *
-	 * @param string $url URL.
-	 * @return string Extension.
-	 */
-	public function get_url_extension( string $url ): string {
-		
-		// Cleanups.
-		$url = trim( $url );
-		// Remove query parameters.
-		$url = preg_replace( '/\?.*$/', '', $url );
-		// Remove fragment identifier.
-		$url = preg_replace( '/#.*$/', '', $url );
-		// Remove trailing slash.
-		$url = rtrim( $url, '/' );
-		
-		// Get the path segment.
-		$parsed_url = wp_parse_url( $url );
-		$path       = $parsed_url['path'] ?? '';
-		if ( empty( $path ) || '/' === $path ) {
-			return '';
-		}
-		
-		// Get extension of the path segment.
-		$extension = pathinfo( $path, PATHINFO_EXTENSION );
-
-		return $extension;
+		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'See the CSV file for results: %s', $csv_file ) );
 	}
 
 	/**
 	 * Callable for `newspack-post-image-downloader import-non-images-files`.
 	 * See command description in \NewspackPostImageDownloader\Downloader::register_commands.
 	 *
-	 * @param array $args       CLI arguments.
+	 * @param array $pos_args   CLI arguments.
 	 * @param array $assoc_args CLI associative arguments.
 	 */
-	public function cmd_import_non_images_files( $args, $assoc_args ) {
-		$dry_run                       = isset( $assoc_args['dry-run'] ) ? true : false;
-		$extensions                    = explode( ',', $assoc_args['extensions'] );
-		$do_not_download_relative_urls = isset( $assoc_args['do-not-download-relative-urls'] ) ? true : false;
-		$post_types                    = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
-		$post_statuses                 = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
-		$post_ids_specific             = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
-		$post_id_from                  = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
-		$post_id_to                    = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
-		$hosts_excluded                = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
-		$only_download_from_hosts      = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
-		$default_image_host_and_schema = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
-		$folder_local_images           = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
+	public function cmd_download_non_images_files( $pos_args, $assoc_args ) {
+		$dry_run                                = isset( $assoc_args['dry-run'] ) ? true : false;
+		$extensions                             = explode( ',', $assoc_args['extensions'] );
+		$do_not_download_root_relative_urls     = isset( $assoc_args['do-not-download-root-relative-urls'] ) ? true : false;
+		$do_not_download_protocol_relative_urls = isset( $assoc_args['do-not-download-protocol-relative-urls'] ) ? true : false;
+		$post_types                             = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
+		$post_statuses                          = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
+		$post_ids_specific                      = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
+		$post_id_from                           = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
+		$post_id_to                             = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
+		$hosts_excluded                         = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
+		$only_download_from_hosts               = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
+		$default_image_host_and_schema          = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
+		$folder_local_images                    = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
 
 		$this->init_loggers( __FUNCTION__ );
 		if ( empty( $extensions ) ) {
@@ -951,6 +899,14 @@ class Downloader {
 			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When providing the `--only-download-from-hosts` param, do not use the `--exclude-hosts` at the same time.' );
 			exit;
 		}
+
+		// Prepare the CSV file.
+		$csv_file = __FUNCTION__ . '__downloaded.csv';
+		if ( $this->file_exists( $csv_file ) ) {
+			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
+		}
+		$csv_file_handle = fopen( $csv_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
+		fputcsv( $csv_file_handle, [ 'post_id', 'url_original', 'attachment_id', 'url_downloaded' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 		global $wpdb;
 		$time_start        = microtime( true );
@@ -988,17 +944,14 @@ class Downloader {
 				$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::WARNING, sprintf( 'No post content in post ID %d, skipping...', $post_id ) );
 				continue;
 			}
-			MemoryCleanupHook::cleanup( 0, $key_post + 1, 20 );
+			MemoryCleanupHook::cleanup( 0, $key_post + 1, 10 );
 
 			// Get all URLs with extensions from HTML.
 			$urls_all        = $this->get_urls_from_html( $post_content );
 			$urls_extensions = [];
 			foreach ( $urls_all as $url ) {
-				// Basic URL validation -- either relative, or absolute and valid.
-				$is_relative  = 0 === strpos( $url, '/' );
-				$is_absolute  = 0 === strpos( strtolower( $url ), 'http' );
-				$is_url_valid = $is_relative || ( $is_absolute && filter_var( $url, FILTER_VALIDATE_URL ) );
-				if ( ! $is_url_valid ) {
+				// Validate URL.
+				if ( ! $this->is_url_valid( $url ) ) {
 					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Invalid URL type '%s'", $url ), [ 'post_id' => $post_id ] );
 					continue;
 				}
@@ -1016,22 +969,29 @@ class Downloader {
 			// Download the filtered URLs.
 			$post_content_updated = $post_content;
 			foreach ( $urls_extensions as $url ) {
-				// Basic URL validation -- either relative, or absolute and valid.
-				$is_relative  = 0 === strpos( $url, '/' );
-				$is_absolute  = 0 === strpos( strtolower( $url ), 'http' );
-				$is_url_valid = $is_relative || ( $is_absolute && filter_var( $url, FILTER_VALIDATE_URL ) );
+				$is_absolute          = $this->is_url_absolute( $url );
+				$is_root_relative     = $this->is_url_root_relative( $url );
+				$is_protocol_relative = $this->is_url_protocol_relative( $url );
 
-				// Skip relative URLs if the flag is set.
-				if ( $is_relative && $do_not_download_relative_urls ) {
-					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, relative URL '%s'", $url ), [ 'post_id' => $post_id ] );
+				// Skip root-relative URLs if the flag is set.
+				if ( $is_root_relative && $do_not_download_root_relative_urls ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, root-relative URL '%s'", $url ), [ 'post_id' => $post_id ] );
+					continue;
+				}
+				// Skip protocol-relative URLs if the flag is set.
+				if ( $is_protocol_relative && $do_not_download_protocol_relative_urls ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, protocol-relative URL '%s'", $url ), [ 'post_id' => $post_id ] );
 					continue;
 				}
 
 				// Filter URL by host.
 				if ( $only_download_from_hosts ) {
-					// Skip if relative URL host (--default-image-host-and-schema) does not match $only_download_from_hosts.
-					if ( $is_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
-						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping relative URL, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+					// Skip if root-relative URL host (--default-image-host-and-schema) does not match $only_download_from_hosts.
+					if ( $is_root_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;
+					} elseif ( $is_protocol_relative && ! $this->does_uri_match_host( 'https:' . $url, $only_download_from_hosts ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping protocol-relative URL, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_absolute && ! $this->does_uri_match_host( $url, $only_download_from_hosts ) ) {
 						// Skip if absolute URL host does not match $only_download_from_hosts.
@@ -1039,9 +999,12 @@ class Downloader {
 						continue;
 					}
 				} elseif ( $hosts_excluded ) {
-					// Skip if relative URL host matches $hosts_excluded.
-					if ( $is_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
-						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping relative URL, excluded host '%s'", $url ), [ 'post_id' => $post_id ] );
+					// Skip if root-relative URL host matches $hosts_excluded.
+					if ( $is_root_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, excluded host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;
+					} elseif ( $is_protocol_relative && $this->does_uri_match_host( 'https:' . $url, $hosts_excluded ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping protocol-relative URL, excluded host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_absolute && $this->does_uri_match_host( $url, $hosts_excluded ) ) {
 						// Skip if absolute URL host matches $hosts_excluded.
@@ -1071,6 +1034,9 @@ class Downloader {
 				// Download the file.
 				$attachment_id = ! $dry_run ? $attachments_logic->import_external_file( $file_import_path, $title, null, null, null, $post_id ) : 'N/A';
 				if ( is_wp_error( $attachment_id ) ) {
+					// CSV, log error.
+					fputcsv( $csv_file_handle, [ $post_id, $url, sprintf( 'ERROR: %s', $attachment_id->get_error_message() ), '' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+
 					$this->log(
 						self::LOG_OUTPUTS['CLI_AND_FILE'],
 						LogLevel::ERROR,
@@ -1096,6 +1062,9 @@ class Downloader {
 				// Replace $url with imported URL.
 				$url_imported         = ! $dry_run ? wp_get_attachment_url( $attachment_id ) : 'n/a';
 				$post_content_updated = str_replace( $url, $url_imported, $post_content_updated );
+
+				// CSV, add the imported file to the CSV file.
+				fputcsv( $csv_file_handle, [ $post_id, $url, $attachment_id, $url_imported ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 			}
 
 			// Update the Post content.
@@ -1107,67 +1076,72 @@ class Downloader {
 			}
 		}
 
+		fclose( $csv_file_handle );
+
 		// Required for the $wpdb->update() to sink in.
 		wp_cache_flush();
 
 		// Closing remarks.
 		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'All done!  🙌  Took %d mins.', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
+		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'See the CSV file for results: %s', $csv_file ) );
 	}
 
 	/**
-	 * Searches for all image URLs in post contents.
-	 * Only supports absolute and relative URLs (not data URLs e.g. data:image/png;base64,...).
+	 * Extracts all absolute and relative URLs from a HTML content.
+	 * Searches in HTML as a string, and not as a DOM.
 	 *
-	 * @param string $post_content The post content.
-	 *
-	 * @return array An array containing image URL hostnames as values, plus a special value
-	 *               "relative URL paths" if there are relative URLs in post_content.
+	 * @param string $html HTML content.
+	 * @return array Array of matched URLs.
 	 */
-	public function get_all_image_hostnames_from_post_content( string $post_content ): array {
-		if ( empty( $post_content ) ) {
-			return [];
+	public function get_urls_from_html( string $html ): array {
+		/**
+		 * (?<=[\'"\s\n\r\t])           = Ensure the match is *preceded* by a quote (' or "), whitespace, newline, carriage return, or tab
+		 *                                to increase likelihood it's part of an HTML attribute or text content.
+		 * (                            = Start of main capture group:
+		 *   https?://[^\s"\'>\n\r\t]+  = Match http or https absolute URLs (non-greedy up to next space, quote, angle bracket, or line break).
+		 *   |                          = OR
+		 *   /[^\s"\'>\n\r\t]+          = Match relative URLs that start with a forward slash.
+		 * )                            = End of capture group.
+		 * #i                           = Case-insensitive delimiter.
+		 */
+		$pattern = '#(?<=[\'"\s\n\r\t])(https?://[^\s"\'>\n\r\t]+|/[^\s"\'>\n\r\t]+)#i';
+		preg_match_all( $pattern, $html, $matches );
+	
+		// Unique URLs.
+		$urls = array_unique( $matches[0] );
+
+		return $urls;
+	}
+
+	/**
+	 * Gets the extension of a URL path segment (i.e. the URLs file extension).
+	 * Works on absolute, root-relative, and protocol-relative URLs.
+	 *
+	 * @param string $url URL.
+	 * @return string Extension.
+	 */
+	public function get_url_extension( string $url ): string {
+		
+		// Cleanups.
+		$url = trim( $url );
+		// Remove query parameters.
+		$url = preg_replace( '/\?.*$/', '', $url );
+		// Remove fragment identifier.
+		$url = preg_replace( '/#.*$/', '', $url );
+		// Remove trailing slash.
+		$url = rtrim( $url, '/' );
+		
+		// Get the path segment.
+		$parsed_url = wp_parse_url( $url );
+		$path       = $parsed_url['path'] ?? '';
+		if ( empty( $path ) || '/' === $path ) {
+			return '';
 		}
+		
+		// Get extension of the path segment.
+		$extension = pathinfo( $path, PATHINFO_EXTENSION );
 
-		$img_srcs = $this->get_all_img_srcs( $post_content );
-		if ( empty( $img_srcs ) ) {
-			return [];
-		}
-
-		$img_hostnames = [];
-		foreach ( $img_srcs as $img_src ) {
-
-			// Basic URL validation -- either relative, or absolute and valid.
-			$is_relative  = 0 === strpos( $img_src, '/' );
-			$is_absolute  = 0 === strpos( strtolower( $img_src ), 'http' );
-			$is_url_valid = $is_relative || ( $is_absolute && filter_var( $img_src, FILTER_VALIDATE_URL ) );
-			if ( ! $is_url_valid ) {
-				continue;
-			}
-
-			$parsed = wp_parse_url( $img_src );
-			if ( false === $parsed ) {
-				continue;
-			}
-
-			$hostname = $parsed['host'] ?? null;
-			if ( $is_absolute && $hostname ) {
-				if ( in_array( $hostname, $img_hostnames ) ) {
-					continue;
-				}
-				$img_hostnames[] = $hostname;
-			} elseif ( $is_relative ) {
-				// Add the special 'relative URL paths' value to the list of hostnames.
-				if ( in_array( 'relative URL paths', $img_hostnames ) ) {
-					continue;
-				}
-				$img_hostnames[] = 'relative URL paths';
-			} else {
-				// Edge cases, like `src="data:image/svg+xml;base64"` or absolute but invalid URLs "http://example.com:invalid".
-				continue;
-			}
-		}
-
-		return $img_hostnames;
+		return $extension;
 	}
 
 	/**
@@ -1249,11 +1223,8 @@ class Downloader {
 		foreach ( $img_data as $key_img_datum => $img_datum ) {
 			$src = trim( $img_datum['src'] );
 
-			// Basic URL validation -- either relative, or absolute and valid.
-			$is_relative  = 0 === strpos( $src, '/' );
-			$is_absolute  = 0 === strpos( strtolower( $src ), 'http' );
-			$is_url_valid = $is_relative || ( $is_absolute && filter_var( $src, FILTER_VALIDATE_URL ) );
-			if ( ! $is_url_valid ) {
+			// Validate URL.
+			if ( ! $this->is_url_valid( $src ) ) {
 				continue;
 			}
 
@@ -1422,33 +1393,39 @@ class Downloader {
 		}
 
 		/**
-		 * Handles three types of `src`s like this:
+		 * Handles four types of `src`s like this:
 		 *      - an absolute HTTP URL, e.g. 'https://host.com/img.jpg'
+		 *      - a protocol-relative URL, e.g. '//cdn.host.com/img.jpg'
 		 *      - a relative reference from root, e.g. '/segment/img.jpg', and uses the `--default-image-host-and-schema` to try
 		 *        and download it
 		 *      - a relative reference without the beginning `/`, e.g. 'segment/img.jpg'. Although this could also be a different
 		 *        kind of `src`, e.g. `src="data:image/svg+xml;base64..."`, it still tries to transform it to a fully qualified
 		 *        URL by using the `--default-image-host-and-schema` to download from.
 		 */
-		$is_src_relative = 0 === strpos( $src, '/' );
-		$is_src_absolute = 0 === strpos( strtolower( $src ), 'http' );
+		$is_absolute          = $this->is_url_absolute( $src );
+		$is_root_relative     = $this->is_url_root_relative( $src );
+		$is_protocol_relative = $this->is_url_protocol_relative( $src );
 
 		// If no local image file is used, get a fully qualified remote URI.
-		if ( $is_src_absolute ) {
+		if ( $is_absolute ) {
 			// A good old absolute URL.
 			$img_import_path = $src;
-		} elseif ( $is_src_relative && ! $default_image_host_and_schema ) {
-			return new WP_Error(
-				'no_default_host_provided',
-				sprintf( "Could not download relative src '%s' since --default-image-host-and-schema was not provided.", esc_url( $src ) ),
-				wp_json_encode( [ 'src' => $src ] )
-			);
-		} elseif ( $is_src_relative && $default_image_host_and_schema ) {
-			// Use the `--default-image-host-and-schema` to try and download a relative URL.
+		} elseif ( $is_protocol_relative ) {
+			// Transform protocol-relative URL to absolute URL.
+			$img_import_path = 'https:' . $src;
+		} elseif ( $is_root_relative ) {
+			if ( ! $default_image_host_and_schema ) {
+				return new WP_Error(
+					'no_default_host_provided',
+					sprintf( "Could not download relative src '%s' since --default-image-host-and-schema was not provided.", esc_url( $src ) ),
+					wp_json_encode( [ 'src' => $src ] )
+				);
+			}
+			// Use the `--default-image-host-and-schema` to try and download a root-relative URL.
 			$img_import_path = $default_image_host_and_schema
 				. ( ( 0 !== strpos( strtolower( $src ), '/' ) ) ? '/' : '' )
 				. $src;
-		} elseif ( ! $is_src_relative && ! $is_src_absolute ) {
+		} else {
 			return new WP_Error(
 				'invalid_url_type',
 				sprintf( "Could not download unsupported src type '%s'.", esc_url( $src ) ),
@@ -1511,6 +1488,75 @@ class Downloader {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks if a URL is absolute, i.e. starting with `http` or `https`, e.g. `https://example.com/path`.
+	 * 
+	 * @param string $url URL.
+	 * 
+	 * @return bool True if the URL is absolute, false otherwise.
+	 */
+	public function is_url_absolute( string $url ): bool {
+		return 0 === strpos( strtolower( $url ), 'http' );
+	}
+
+	/**
+	 * Checks if a URL is root-relative, i.e. starting with `/`, e.g. `/path/to/image.jpg`.
+	 * 
+	 * @param string $url URL.
+	 * 
+	 * @return bool True if the URL is relative, false otherwise.
+	 */
+	public function is_url_root_relative( string $url ): bool {
+		$ends_with_single_slash = 0 === strpos( $url, '/' );
+		$is_protocol_relative   = $this->is_url_protocol_relative( $url );
+		
+		return $ends_with_single_slash && ! $is_protocol_relative;
+	}
+
+	/**
+	 * Checks if a URL is protocol-relative, i.e. starting with `//`, e.g. `//example.com/path`.
+	 * 
+	 * @param string $url URL.
+	 * 
+	 * @return bool True if the URL is relative, false otherwise.
+	 */
+	public function is_url_protocol_relative( string $url ): bool {
+		return 0 === strpos( $url, '//' );
+	}
+
+	/**
+	 * Checks if a URL is a valid root-relative (starting with `/`), protocol-relative (starting with `//`), or absolute (starting with `http` or `https`) URL.
+	 * 
+	 * @param string $url URL.
+	 * 
+	 * @return bool True for root-relative, protocol-relative, or absolute URLs, false for other types of URLs like `data:image/svg+xml;base64` or
+	 *              invalid URLs like `http://example.com:invalid`.
+	 */
+	public function is_url_valid( string $url ): bool {
+		$is_root_relative     = $this->is_url_root_relative( $url );
+		$is_protocol_relative = $this->is_url_protocol_relative( $url );
+		$is_absolute          = $this->is_url_absolute( $url );
+
+		$is_valid = false;
+		if ( $is_root_relative ) {
+			$is_valid = ! empty( $url ) && 
+				0 === strpos( $url, '/' ) && 
+				0 !== strpos( $url, '//' ) && 
+				null === wp_parse_url( $url, PHP_URL_HOST ) && 
+				false !== filter_var( 'https://example.com' . $url, FILTER_VALIDATE_URL );
+		} elseif ( $is_protocol_relative ) {
+			$is_valid = ! empty( $url ) && 
+				0 === strpos( $url, '//' ) && 
+				false !== filter_var( 'https:' . $url, FILTER_VALIDATE_URL );
+		} elseif ( $is_absolute ) {
+			$is_valid = ! empty( $url ) && 
+				false !== filter_var( $url, FILTER_VALIDATE_URL ) && 
+				in_array( wp_parse_url( $url, PHP_URL_SCHEME ), [ 'http', 'https' ], true );
+		}
+
+		return $is_valid;
 	}
 
 	/**
@@ -1595,7 +1641,25 @@ class Downloader {
 		}
 
 		foreach ( $crawler->getIterator() as $node ) {
-			$img_srcs[] = $node->getAttribute( 'src' );
+			// Extract src attribute.
+			$src = $node->attr( 'src' );
+			if ( ! empty( $src ) ) {
+				$img_srcs[] = $src;
+			}
+
+			// Extract srcset attribute and parse individual URLs.
+			$srcset = $node->attr( 'srcset' );
+			if ( ! empty( $srcset ) ) {
+				$srcset_urls = $this->extract_urls_from_srcset( $srcset );
+				$img_srcs    = array_merge( $img_srcs, $srcset_urls );
+			}
+
+			// Extract data-srcset attribute and parse individual URLs.
+			$data_srcset = $node->attr( 'data-srcset' );
+			if ( ! empty( $data_srcset ) ) {
+				$data_srcset_urls = $this->extract_urls_from_srcset( $data_srcset );
+				$img_srcs         = array_merge( $img_srcs, $data_srcset_urls );
+			}
 		}
 
 		// Unique values and updated keys.
@@ -1612,32 +1676,61 @@ class Downloader {
 	}
 
 	/**
-	 * Gets all the unique and trimmed URLs in HTML from `href` and `src` attributes.
+	 * Gets unique and valid (supported absolute and root-relative) URLs from HTML.
+	 * 
+	 * First fetches URLs from various DOM attributes, and then additionally extracts just absolute URLs from text content.
+	 * This hybrid approach optimizes for accuracy and relevance.
 	 *
 	 * @param string $html HTML.
 	 *
-	 * @return array An array of URLs found in the HTML.
+	 * @return array An array of unique and valid/supported URLs.
 	 */
-	private function get_all_urls( string $html ): array {
+	public function get_all_urls( string $html ): array {
 		$urls    = [];
 		$crawler = new Crawler( $html );
 		
-		// Extract all href attributes.
-		$crawler->filter( '[href]' )->each(
-			function ( $node ) use ( &$urls ) {
-				$urls[] = $node->attr( 'href' );
-			}
-		);
-		
-		// Extract all src attributes.
-		$crawler->filter( '[src]' )->each(
-			function ( $node ) use ( &$urls ) {
-				$urls[] = $node->attr( 'src' );
-			}
-		);
+		/**
+		 * First, extract URLs from various DOM attributes.
+		 */
+		// Simple attributes that contain single URLs.
+		$simple_attributes = [
+			'href',
+			'src',
+			'data-src',
+			'data-background',
+			'data-lazy-src',
+			'data-url',
+			'data-href',
+			'poster',
+			'data-poster',
+			'data-thumbnail',
+			'data-preview',
+		];
+		foreach ( $simple_attributes as $attribute ) {
+			$crawler->filter( "[{$attribute}]" )->each(
+				function ( $node ) use ( &$urls, $attribute ) {
+					$urls[] = $node->attr( $attribute );
+				}
+			);
+		}
+		// Handle srcsets with  multiple URLs.
+		$srcset_attributes = [ 'srcset', 'data-srcset' ];
+		foreach ( $srcset_attributes as $attribute ) {
+			$crawler->filter( "[{$attribute}]" )->each(
+				function ( $node ) use ( &$urls, $attribute ) {
+					$srcset = $node->attr( $attribute );
+					// Parse srcset to extract individual URLs.
+					$urls = array_merge( $urls, $this->extract_urls_from_srcset( $srcset ) );
+				}
+			);
+		}
 
-		// Trim, unique, and remove empty (if it was attributed from an empty node).
-		$urls = array_map( 'trim', $urls );
+		/**
+		 * Then additionally extract just the absolute URLs from entire HTML text.
+		 */
+		$urls = array_merge( $urls, $this->extract_absolute_urls_from_text( $html ) );
+
+		// Clean up results.
 		$urls = array_unique( $urls );
 		$urls = array_filter(
 			$urls,
@@ -1645,8 +1738,65 @@ class Downloader {
 				return ! empty( $url );
 			}
 		);
+		$urls = array_map( 'trim', $urls );
+		
+		// Validate URLs.
+		$urls = array_filter(
+			$urls,
+			function ( $url ) {
+				return $this->is_url_valid( $url );
+			}
+		);
+		
 		// Update keys.
 		$urls = array_values( $urls );
+
+		return $urls;
+	}
+
+	/**
+	 * Extract URLs from srcset attribute.
+	 *
+	 * @param string $srcset The srcset attribute value.
+	 * @return array Array of URLs.
+	 */
+	private function extract_urls_from_srcset( string $srcset ): array {
+		$urls = [];
+		if ( empty( $srcset ) ) {
+			return $urls;
+		}
+
+		// Split srcset by commas and extract URLs.
+		$parts = explode( ',', $srcset );
+		foreach ( $parts as $part ) {
+			$part = trim( $part );
+			// Extract URL before any space (which might be followed by width/height descriptors).
+			$url = preg_replace( '/\s.*$/', '', $part );
+			if ( ! empty( $url ) ) {
+				$urls[] = $url;
+			}
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Extracts only absolute URLs from plain text content.
+	 *
+	 * @param string $text The text content.
+	 * @return array Array of absolute URLs.
+	 */
+	private function extract_absolute_urls_from_text( string $text ): array {
+		$urls = [];
+		if ( empty( $text ) ) {
+			return $urls;
+		}
+
+		// Match only absolute URLs (http/https).
+		preg_match_all( '/https?:\/\/[^\s"<>]+/i', $text, $matches );
+		if ( isset( $matches[0] ) ) {
+			$urls = array_merge( $urls, $matches[0] );
+		}
 
 		return $urls;
 	}

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -396,7 +396,7 @@ class Downloader {
 
 			// Get all URLs, or just image `src`s.
 			$urls = $include_non_image_urls
-				? $this->get_all_urls( $post_content )
+				? $this->get_all_urls_from_html( $post_content )
 				: $this->get_all_img_srcs( $post_content );
 			if ( empty( $urls ) ) {
 				continue;
@@ -947,7 +947,7 @@ class Downloader {
 			MemoryCleanupHook::cleanup( 0, $key_post + 1, 10 );
 
 			// Get all URLs with extensions from HTML.
-			$urls_all        = $this->get_urls_from_html( $post_content );
+			$urls_all        = $this->get_all_urls_from_html( $post_content );
 			$urls_extensions = [];
 			foreach ( $urls_all as $url ) {
 				// Validate URL.
@@ -1084,33 +1084,6 @@ class Downloader {
 		// Closing remarks.
 		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'All done!  🙌  Took %d mins.', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
 		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'See the CSV file for results: %s', $csv_file ) );
-	}
-
-	/**
-	 * Extracts all absolute and relative URLs from a HTML content.
-	 * Searches in HTML as a string, and not as a DOM.
-	 *
-	 * @param string $html HTML content.
-	 * @return array Array of matched URLs.
-	 */
-	public function get_urls_from_html( string $html ): array {
-		/**
-		 * (?<=[\'"\s\n\r\t])           = Ensure the match is *preceded* by a quote (' or "), whitespace, newline, carriage return, or tab
-		 *                                to increase likelihood it's part of an HTML attribute or text content.
-		 * (                            = Start of main capture group:
-		 *   https?://[^\s"\'>\n\r\t]+  = Match http or https absolute URLs (non-greedy up to next space, quote, angle bracket, or line break).
-		 *   |                          = OR
-		 *   /[^\s"\'>\n\r\t]+          = Match relative URLs that start with a forward slash.
-		 * )                            = End of capture group.
-		 * #i                           = Case-insensitive delimiter.
-		 */
-		$pattern = '#(?<=[\'"\s\n\r\t])(https?://[^\s"\'>\n\r\t]+|/[^\s"\'>\n\r\t]+)#i';
-		preg_match_all( $pattern, $html, $matches );
-	
-		// Unique URLs.
-		$urls = array_unique( $matches[0] );
-
-		return $urls;
 	}
 
 	/**
@@ -1685,7 +1658,7 @@ class Downloader {
 	 *
 	 * @return array An array of unique and valid/supported URLs.
 	 */
-	public function get_all_urls( string $html ): array {
+	public function get_all_urls_from_html( string $html ): array {
 		$urls    = [];
 		$crawler = new Crawler( $html );
 		

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -397,7 +397,7 @@ class Downloader {
 			// Get all URLs, or just image `src`s.
 			$urls = $include_non_image_urls
 				? $this->get_all_urls_from_html( $post_content )
-				: $this->get_all_img_srcs( $post_content );
+				: $this->get_all_img_srcs_from_html( $post_content );
 			if ( empty( $urls ) ) {
 				continue;
 			}
@@ -1596,13 +1596,13 @@ class Downloader {
 	}
 
 	/**
-	 * Gets all the unique `<img>` `src` attributes in post.
+	 * Gets all the unique <img> `src` and `srcset` URLs from HTML.
 	 *
 	 * @param string $html HTML.
 	 *
 	 * @return array
 	 */
-	private function get_all_img_srcs( $html ) {
+	public function get_all_img_srcs_from_html( $html ) {
 		$img_srcs = [];
 
 		$crawler = ( new Crawler( $html ) )->filter( 'img' );
@@ -1620,14 +1620,14 @@ class Downloader {
 			// Extract srcset attribute and parse individual URLs.
 			$srcset = $node->attr( 'srcset' );
 			if ( ! empty( $srcset ) ) {
-				$srcset_urls = $this->extract_urls_from_srcset( $srcset );
+				$srcset_urls = $this->get_urls_from_srcset( $srcset );
 				$img_srcs    = array_merge( $img_srcs, $srcset_urls );
 			}
 
 			// Extract data-srcset attribute and parse individual URLs.
 			$data_srcset = $node->attr( 'data-srcset' );
 			if ( ! empty( $data_srcset ) ) {
-				$data_srcset_urls = $this->extract_urls_from_srcset( $data_srcset );
+				$data_srcset_urls = $this->get_urls_from_srcset( $data_srcset );
 				$img_srcs         = array_merge( $img_srcs, $data_srcset_urls );
 			}
 		}
@@ -1646,10 +1646,10 @@ class Downloader {
 	}
 
 	/**
-	 * Gets unique and valid (supported absolute and root-relative) URLs from HTML.
-	 * 
-	 * First fetches URLs from various DOM attributes, and then additionally extracts just absolute URLs from text content.
-	 * This hybrid approach optimizes for accuracy and relevance.
+	 * Gets unique URLs from HTML.
+	 * Supported URL types are absolute, root-relative (e.g. `/path/to/image.jpg`) and protocol-relative (e.g. `//example.com/path/to/image.jpg`), but not `data` B64 or page-relative URLs (e.g. `../page/image.jpg`).
+	 * First fetches URLs from various DOM attributes to get the most relevant URLs, and then additionally extracts just potential remaining 
+	 * absolute URLs from text content. This hybrid approach tries to optimize relevance and accuracy.
 	 *
 	 * @param string $html HTML.
 	 *
@@ -1690,7 +1690,7 @@ class Downloader {
 				function ( $node ) use ( &$urls, $attribute ) {
 					$srcset = $node->attr( $attribute );
 					// Parse srcset to extract individual URLs.
-					$urls = array_merge( $urls, $this->extract_urls_from_srcset( $srcset ) );
+					$urls = array_merge( $urls, $this->get_urls_from_srcset( $srcset ) );
 				}
 			);
 		}
@@ -1698,7 +1698,7 @@ class Downloader {
 		/**
 		 * Then additionally extract just the absolute URLs from entire HTML text.
 		 */
-		$urls = array_merge( $urls, $this->extract_absolute_urls_from_text( $html ) );
+		$urls = array_merge( $urls, $this->get_absolute_urls_from_text( $html ) );
 
 		// Clean up results.
 		$urls = array_unique( $urls );
@@ -1725,12 +1725,33 @@ class Downloader {
 	}
 
 	/**
+	 * Extracts only absolute URLs from plain text content.
+	 *
+	 * @param string $text The text content.
+	 * @return array Array of absolute URLs.
+	 */
+	public function get_absolute_urls_from_text( string $text ): array {
+		$urls = [];
+		if ( empty( $text ) ) {
+			return $urls;
+		}
+
+		// Match only absolute URLs (http/https).
+		preg_match_all( '/https?:\/\/[^\s"<>]+/i', $text, $matches );
+		if ( isset( $matches[0] ) ) {
+			$urls = array_merge( $urls, $matches[0] );
+		}
+
+		return $urls;
+	}
+
+	/**
 	 * Extract URLs from srcset attribute.
 	 *
 	 * @param string $srcset The srcset attribute value.
 	 * @return array Array of URLs.
 	 */
-	private function extract_urls_from_srcset( string $srcset ): array {
+	public function get_urls_from_srcset( string $srcset ): array {
 		$urls = [];
 		if ( empty( $srcset ) ) {
 			return $urls;
@@ -1751,27 +1772,6 @@ class Downloader {
 	}
 
 	/**
-	 * Extracts only absolute URLs from plain text content.
-	 *
-	 * @param string $text The text content.
-	 * @return array Array of absolute URLs.
-	 */
-	private function extract_absolute_urls_from_text( string $text ): array {
-		$urls = [];
-		if ( empty( $text ) ) {
-			return $urls;
-		}
-
-		// Match only absolute URLs (http/https).
-		preg_match_all( '/https?:\/\/[^\s"<>]+/i', $text, $matches );
-		if ( isset( $matches[0] ) ) {
-			$urls = array_merge( $urls, $matches[0] );
-		}
-
-		return $urls;
-	}
-
-	/**
 	 * Attempts to determine image file extension from the mime encoding of the image file.
 	 * 
 	 * Note, this method was previously used, presently discontinued, but could again be used in the future.
@@ -1780,7 +1780,7 @@ class Downloader {
 	 *
 	 * @return string|null Image format extension, no dot.
 	 */
-	private function get_image_extension_from_binary_file( $filename ) {
+	public function get_image_extension_from_binary_file( $filename ) {
 		$extension = null;
 
 		$mime_type       = ( new \finfo( FILEINFO_MIME ) )->file( $filename );

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -402,6 +402,8 @@ class Downloader {
 				continue;
 			}
 			foreach ( $urls as $url ) {
+				$url = trim( $url );
+
 				// Validate URL.
 				$is_absolute          = $this->is_url_absolute( $url );
 				$is_root_relative     = $this->is_url_root_relative( $url );
@@ -969,6 +971,8 @@ class Downloader {
 			// Download the filtered URLs.
 			$post_content_updated = $post_content;
 			foreach ( $urls_extensions as $url ) {
+				$url = trim( $url );
+
 				$is_absolute          = $this->is_url_absolute( $url );
 				$is_root_relative     = $this->is_url_root_relative( $url );
 				$is_protocol_relative = $this->is_url_protocol_relative( $url );
@@ -1462,23 +1466,27 @@ class Downloader {
 
 	/**
 	 * Checks if a URL is absolute, i.e. starting with `http` or `https`, e.g. `https://example.com/path`.
+	 * Note: this method will trim the input URL before checking if it's absolute.
 	 * 
 	 * @param string $url URL.
 	 * 
 	 * @return bool True if the URL is absolute, false otherwise.
 	 */
 	public function is_url_absolute( string $url ): bool {
+		$url = trim( $url );
 		return 0 === strpos( strtolower( $url ), 'http' );
 	}
 
 	/**
 	 * Checks if a URL is root-relative, i.e. starting with `/`, e.g. `/path/to/image.jpg`.
+	 * Note: this method will trim the input URL before checking if it's root-relative.
 	 * 
 	 * @param string $url URL.
 	 * 
 	 * @return bool True if the URL is relative, false otherwise.
 	 */
 	public function is_url_root_relative( string $url ): bool {
+		$url                    = trim( $url );
 		$ends_with_single_slash = 0 === strpos( $url, '/' );
 		$is_protocol_relative   = $this->is_url_protocol_relative( $url );
 		
@@ -1487,17 +1495,20 @@ class Downloader {
 
 	/**
 	 * Checks if a URL is protocol-relative, i.e. starting with `//`, e.g. `//example.com/path`.
+	 * Note: this method will trim the input URL before checking if it's protocol-relative.
 	 * 
 	 * @param string $url URL.
 	 * 
 	 * @return bool True if the URL is relative, false otherwise.
 	 */
 	public function is_url_protocol_relative( string $url ): bool {
-		return 0 === strpos( $url, '//' );
+		$url = trim( $url );
+		return ( 0 === strpos( $url, '//' ) ) && ! ( 0 === strpos( $url, '///' ) );
 	}
 
 	/**
 	 * Checks if a URL is a valid root-relative (starting with `/`), protocol-relative (starting with `//`), or absolute (starting with `http` or `https`) URL.
+	 * Note: this method will trim the input URL before checking if it's valid.
 	 * 
 	 * @param string $url URL.
 	 * 
@@ -1505,6 +1516,8 @@ class Downloader {
 	 *              invalid URLs like `http://example.com:invalid`.
 	 */
 	public function is_url_valid( string $url ): bool {
+		$url = trim( $url );
+
 		$is_root_relative     = $this->is_url_root_relative( $url );
 		$is_protocol_relative = $this->is_url_protocol_relative( $url );
 		$is_absolute          = $this->is_url_absolute( $url );
@@ -1612,20 +1625,20 @@ class Downloader {
 
 		foreach ( $crawler->getIterator() as $node ) {
 			// Extract src attribute.
-			$src = $node->attr( 'src' );
+			$src = $node->getAttribute( 'src' );
 			if ( ! empty( $src ) ) {
 				$img_srcs[] = $src;
 			}
 
 			// Extract srcset attribute and parse individual URLs.
-			$srcset = $node->attr( 'srcset' );
+			$srcset = $node->getAttribute( 'srcset' );
 			if ( ! empty( $srcset ) ) {
 				$srcset_urls = $this->get_urls_from_srcset( $srcset );
 				$img_srcs    = array_merge( $img_srcs, $srcset_urls );
 			}
 
 			// Extract data-srcset attribute and parse individual URLs.
-			$data_srcset = $node->attr( 'data-srcset' );
+			$data_srcset = $node->getAttribute( 'data-srcset' );
 			if ( ! empty( $data_srcset ) ) {
 				$data_srcset_urls = $this->get_urls_from_srcset( $data_srcset );
 				$img_srcs         = array_merge( $img_srcs, $data_srcset_urls );
@@ -1677,22 +1690,22 @@ class Downloader {
 			'data-preview',
 		];
 		foreach ( $simple_attributes as $attribute ) {
-			$crawler->filter( "[{$attribute}]" )->each(
-				function ( $node ) use ( &$urls, $attribute ) {
-					$urls[] = $node->attr( $attribute );
-				}
-			);
+			$crawler = $crawler->filter( "[{$attribute}]" );
+			foreach ( $crawler->getIterator() as $node ) {
+				$urls[] = $node->getAttribute( $attribute );
+			}
 		}
 		// Handle srcsets with  multiple URLs.
 		$srcset_attributes = [ 'srcset', 'data-srcset' ];
 		foreach ( $srcset_attributes as $attribute ) {
-			$crawler->filter( "[{$attribute}]" )->each(
-				function ( $node ) use ( &$urls, $attribute ) {
-					$srcset = $node->attr( $attribute );
-					// Parse srcset to extract individual URLs.
+			$crawler = $crawler->filter( "[{$attribute}]" );
+			foreach ( $crawler->getIterator() as $node ) {
+				// Extract URLs from srcset.
+				$srcset = $node->getAttribute( $attribute );
+				if ( ! empty( $srcset ) ) {
 					$urls = array_merge( $urls, $this->get_urls_from_srcset( $srcset ) );
 				}
-			);
+			}
 		}
 
 		/**

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -272,6 +272,98 @@ class Downloader {
 				],
 			]
 		);
+		WP_CLI::add_command(
+			'newspack-post-image-downloader import-non-images-files',
+			[ $this, 'cmd_import_non_images_files' ],
+			[
+				'shortdesc' => 'Downloads other non-image files to local.',
+				'synopsis'  => [
+					[
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'description' => 'Perform a dry run, making no changes.',
+						'optional'    => true,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'default-host-and-schema',
+						'description' => 'Used for relative URLs, provide the full schema and hostname where to download these from, e.g. `https://defaulthost.com`.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'extensions',
+						'description' => 'CSV list of extensions to download. E.g. --extensions=pdf,docx,xlsx,pptx',
+						'optional'    => false,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'flag',
+						'name'        => 'do-not-download-relative-urls',
+						'description' => 'Unless this flag is set, the command will automatically download relative image URLs by prepending the --default-image-host-and-schema to them.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'exclude-hosts',
+						'description' => 'CSV, list of hosts to exclude downloading from. Can use a wildcard, e.g. to cover a host and all its subdomains, use these two values `google.com,*.google.com`, or for multiple domain extensions use `www.google.*`, or can even use `*.google.*` for all subdomains and all domain extensions.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'only-download-from-hosts',
+						'description' => 'CSV, list of specific hosts to download images from. If provided, it will skip downloading from any other host, and if this param is provided, the `exclude-param` will not work. Can use a wildcard, e.g. to cover a host and all its subdomains, use these two values `somehost.com,*.somehost.com`, or for multiple domain extensions use `www.somehost.*`, or can even use `*.somehost.*` for all subdomains and all domain extensions.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'folder-local-files',
+						'description' => 'Local folder which contains the files. Files which are found here, get imported from local files, otherwise they get downloaded via HTTP.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'post-types',
+						'description' => 'Optional CSV Post types. Defaults are `post,page`',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'post-statuses',
+						'description' => 'Optional CSV Post statuses. Defaults is `publish`',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'post-ids-csv',
+						'description' => 'CSV list of Post IDs.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'post-id-from',
+						'description' => 'Only scan Post IDs from-to.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
+						'name'        => 'post-id-to',
+						'description' => 'Only scan Post IDs from-to.',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -745,6 +837,265 @@ class Downloader {
 						] 
 					);
 				}
+			}
+
+			// Update the Post content.
+			if ( ! $dry_run && $post_content_updated != $post_content ) {
+				$wpdb->update( $wpdb->prefix . 'posts', [ 'post_content' => $post_content_updated ], [ 'ID' => $post_id ] ); // phpcs:ignore -- WordPress.DB.DirectDatabaseQuery.NoCaching.
+				$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( '✓ Post content updated 👍' ), [ 'post_id' => $post_id ] );
+			} elseif ( $dry_run && $post_content_updated != $post_content ) {
+				$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( '✓ Post content updated 👍' ), [ 'post_id' => $post_id ] );
+			}
+		}
+
+		// Required for the $wpdb->update() to sink in.
+		wp_cache_flush();
+
+		// Closing remarks.
+		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( 'All done!  🙌  Took %d mins.', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
+	}
+
+	/**
+	 * Extracts all absolute and relative URLs from a HTML content.
+	 * Searches in HTML as a string, and not as a DOM.
+	 *
+	 * @param string $html HTML content.
+	 * @return array Array of matched URLs.
+	 */
+	public function get_urls_from_html( string $html ): array {
+	
+		/**
+		 * (?<=[\'"\s\n\r\t])           = Ensure the match is *preceded* by a quote (' or "), whitespace, newline, carriage return, or tab
+		 *                                to increase likelihood it's part of an HTML attribute or text content.
+		 * (                            = Start of main capture group:
+		 *   https?://[^\s"\'>\n\r\t]+  = Match http or https absolute URLs (non-greedy up to next space, quote, angle bracket, or line break).
+		 *   |                          = OR
+		 *   /[^\s"\'>\n\r\t]+          = Match relative URLs that start with a forward slash.
+		 * )                            = End of capture group.
+		 * #i                           = Case-insensitive delimiter.
+		 */
+		$pattern = '#(?<=[\'"\s\n\r\t])(https?://[^\s"\'>\n\r\t]+|/[^\s"\'>\n\r\t]+)#i';
+		preg_match_all( $pattern, $html, $matches );
+	
+		// Unique URLs.
+		$urls = array_unique( $matches[0] );
+
+		return $urls;
+	}
+
+	/**
+	 * Gets the extension of a URL path segment (i.e. the URLs file extension).
+	 *
+	 * @param string $url URL.
+	 * @return string Extension.
+	 */
+	public function get_url_extension( string $url ): string {
+		
+		// Cleanups.
+		$url = trim( $url );
+		// Remove query parameters.
+		$url = preg_replace( '/\?.*$/', '', $url );
+		// Remove fragment identifier.
+		$url = preg_replace( '/#.*$/', '', $url );
+		// Remove trailing slash.
+		$url = rtrim( $url, '/' );
+		
+		// Get the path segment.
+		$parsed_url = wp_parse_url( $url );
+		$path       = $parsed_url['path'] ?? '';
+		if ( empty( $path ) || '/' === $path ) {
+			return '';
+		}
+		
+		// Get extension of the path segment.
+		$extension = pathinfo( $path, PATHINFO_EXTENSION );
+
+		return $extension;
+	}
+
+	/**
+	 * Callable for `newspack-post-image-downloader import-non-images-files`.
+	 * See command description in \NewspackPostImageDownloader\Downloader::register_commands.
+	 *
+	 * @param array $args       CLI arguments.
+	 * @param array $assoc_args CLI associative arguments.
+	 */
+	public function cmd_import_non_images_files( $args, $assoc_args ) {
+		$dry_run                       = isset( $assoc_args['dry-run'] ) ? true : false;
+		$extensions                    = explode( ',', $assoc_args['extensions'] );
+		$do_not_download_relative_urls = isset( $assoc_args['do-not-download-relative-urls'] ) ? true : false;
+		$post_types                    = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
+		$post_statuses                 = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
+		$post_ids_specific             = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
+		$post_id_from                  = isset( $assoc_args['post-id-from'] ) ? (int) $assoc_args['post-id-from'] : null;
+		$post_id_to                    = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
+		$hosts_excluded                = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
+		$only_download_from_hosts      = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
+		$default_image_host_and_schema = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
+		$folder_local_images           = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
+
+		$this->init_loggers( __FUNCTION__ );
+		if ( empty( $extensions ) ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Must provide a list of extensions to download, e.g. --extensions=pdf,docx,xlsx,pptx' );
+			exit;
+		}
+		if ( ( $post_ids_specific && $post_id_from ) || ( $post_ids_specific && $post_id_to ) ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Sorry, you can either specify a CSV list of Post IDs, or a range of Post IDs.' );
+			exit;
+		}
+		if ( ( $post_id_from && ( null === $post_id_to ) ) || ( ( null === $post_id_from ) && $post_id_to ) ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ Both --post-id-from and --post-id-to are required when using ranges.' );
+			exit;
+		}
+		if ( $only_download_from_hosts && $hosts_excluded ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When providing the `--only-download-from-hosts` param, do not use the `--exclude-hosts` at the same time.' );
+			exit;
+		}
+
+		global $wpdb;
+		$time_start        = microtime( true );
+		$hosts_excluded    = $this->get_all_excluded_hosts( $hosts_excluded );
+		$attachments_logic = new Attachments();
+		
+		// Normalize extensions to lowercase.
+		$extensions = array_map( 'strtolower', $extensions );
+
+		// Validate extensions.
+		foreach ( $extensions as $extension ) {
+			if ( ! wp_check_filetype( $extension ) ) {
+				$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, sprintf( "❗ Extension '%s' is presently not supported by your site's Media Library (@see `wp_check_filetype()`). Please exclude it from the list of extensions to download, or extend the list of supported extensions.", $extension ) );
+				exit;
+			}
+		}
+
+		// Fetch Posts.
+		$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::DEBUG, 'Fetching Posts...' );
+		$post_ids = $this->get_post_ids( $post_ids_specific, $post_id_from, $post_id_to, $post_types, $post_statuses );
+		if ( empty( $post_ids ) ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::WARNING, 'No Posts found... 🤔' );
+			exit;
+		}
+		MemoryCleanupHook::cleanup();
+
+		// Loop posts and download URLs with extensions.
+		foreach ( $post_ids as $key_post => $post_id ) {
+			// Progress.
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::INFO, sprintf( '(%d)/(%d) post ID %d', $key_post + 1, count( $post_ids ), $post_id ) );
+
+			// Get post content.
+			$post_content = $this->get_post_content( $post_id );
+			if ( empty( $post_content ) ) {
+				$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::WARNING, sprintf( 'No post content in post ID %d, skipping...', $post_id ) );
+				continue;
+			}
+			MemoryCleanupHook::cleanup( 0, $key_post + 1, 20 );
+
+			// Get all URLs with extensions from HTML.
+			$urls_all        = $this->get_urls_from_html( $post_content );
+			$urls_extensions = [];
+			foreach ( $urls_all as $url ) {
+				// Basic URL validation -- either relative, or absolute and valid.
+				$is_relative  = 0 === strpos( $url, '/' );
+				$is_absolute  = 0 === strpos( strtolower( $url ), 'http' );
+				$is_url_valid = $is_relative || ( $is_absolute && filter_var( $url, FILTER_VALIDATE_URL ) );
+				if ( ! $is_url_valid ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Invalid URL type '%s'", $url ), [ 'post_id' => $post_id ] );
+					continue;
+				}
+
+				// Filter by extension.
+				$url_extension = $this->get_url_extension( $url );
+				if ( ! empty( $url_extension ) && in_array( strtolower( $url_extension ), $extensions, true ) ) {
+					$urls_extensions[] = $url;
+				}
+			}
+			if ( empty( $urls_extensions ) ) {
+				continue;
+			}
+
+			// Download the filtered URLs.
+			$post_content_updated = $post_content;
+			foreach ( $urls_extensions as $url ) {
+				// Basic URL validation -- either relative, or absolute and valid.
+				$is_relative  = 0 === strpos( $url, '/' );
+				$is_absolute  = 0 === strpos( strtolower( $url ), 'http' );
+				$is_url_valid = $is_relative || ( $is_absolute && filter_var( $url, FILTER_VALIDATE_URL ) );
+
+				// Skip relative URLs if the flag is set.
+				if ( $is_relative && $do_not_download_relative_urls ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, relative URL '%s'", $url ), [ 'post_id' => $post_id ] );
+					continue;
+				}
+
+				// Filter URL by host.
+				if ( $only_download_from_hosts ) {
+					// Skip if relative URL host (--default-image-host-and-schema) does not match $only_download_from_hosts.
+					if ( $is_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping relative URL, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;
+					} elseif ( $is_absolute && ! $this->does_uri_match_host( $url, $only_download_from_hosts ) ) {
+						// Skip if absolute URL host does not match $only_download_from_hosts.
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;
+					}
+				} elseif ( $hosts_excluded ) {
+					// Skip if relative URL host matches $hosts_excluded.
+					if ( $is_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping relative URL, excluded host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;
+					} elseif ( $is_absolute && $this->does_uri_match_host( $url, $hosts_excluded ) ) {
+						// Skip if absolute URL host matches $hosts_excluded.
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, excluded host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;
+					}
+				}
+
+				// Skip if $url was already used/downloaded and replaced.
+				if ( false === strpos( $post_content_updated, $url ) && false === strpos( $post_content_updated, esc_attr( $url ) ) ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, URL already downloaded '%s'", $url ), [ 'post_id' => $post_id ] );
+					continue;
+				}
+
+				// Get the fully qualified import path of this file (either from local folder, or from remote URL).
+				$file_import_path = $this->get_fully_qualified_img_import_or_download_path( $url, $folder_local_images, $default_image_host_and_schema );
+				if ( is_wp_error( $file_import_path ) ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Error getting file path for '%s', error: %s", $url, $file_import_path->get_error_message() ), [ 'post_id' => $post_id ] );
+					continue;
+				}
+
+				// Set title to image filename (no extension).
+				$basename       = basename( $file_import_path );
+				$filename_parts = pathinfo( $basename );
+				$title          = $filename_parts['filename'];
+
+				// Download the file.
+				$attachment_id = ! $dry_run ? $attachments_logic->import_external_file( $file_import_path, $title, null, null, null, $post_id ) : 'N/A';
+				if ( is_wp_error( $attachment_id ) ) {
+					$this->log(
+						self::LOG_OUTPUTS['CLI_AND_FILE'],
+						LogLevel::ERROR,
+						sprintf( "❗ Error importing file '%s', error: %s", $file_import_path, $attachment_id->get_error_message() ),
+						[
+							'url'     => $url,
+							'post_id' => $post_id,
+						] 
+					);
+					continue;
+				}
+
+				$this->log(
+					self::LOG_OUTPUTS['CLI_AND_FILE'],
+					LogLevel::INFO,
+					sprintf( "✓ %sImported file '%s' to '%s'", $dry_run ? '[Dry Run] ' : '', $file_import_path, $attachment_id ),
+					[
+						'url'     => $url,
+						'post_id' => $post_id,
+					] 
+				);
+
+				// Replace $url with imported URL.
+				$url_imported         = ! $dry_run ? wp_get_attachment_url( $attachment_id ) : 'n/a';
+				$post_content_updated = str_replace( $url, $url_imported, $post_content_updated );
 			}
 
 			// Update the Post content.

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -880,7 +880,7 @@ class Downloader {
 		$hosts_excluded                         = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
 		$only_download_from_hosts               = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
 		$default_image_host_and_schema          = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
-		$folder_local_images                    = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
+		$folder_local_files                     = isset( $assoc_args['folder-local-files'] ) ? rtrim( $assoc_args['folder-local-files'], '/' ) : null;
 
 		$this->init_loggers( __FUNCTION__ );
 		if ( empty( $extensions ) ) {
@@ -1020,7 +1020,7 @@ class Downloader {
 				}
 
 				// Get the fully qualified import path of this file (either from local folder, or from remote URL).
-				$file_import_path = $this->get_fully_qualified_img_import_or_download_path( $url, $folder_local_images, $default_image_host_and_schema );
+				$file_import_path = $this->get_fully_qualified_img_import_or_download_path( $url, $folder_local_files, $default_image_host_and_schema );
 				if ( is_wp_error( $file_import_path ) ) {
 					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Error getting file path for '%s', error: %s", $url, $file_import_path->get_error_message() ), [ 'post_id' => $post_id ] );
 					continue;
@@ -1332,14 +1332,14 @@ class Downloader {
 	 * or else returns a fully qualified HTTP path to download from.
 	 *
 	 * @param string $src                           Img `src` URI.
-	 * @param string $folder_local_images           Path to local folder where image files can be found at.
+	 * @param string $folder_local_files            Path to local folder where image files can be found at.
 	 * @param string $default_image_host_and_schema Default schema+host used to download relative referenced URLs.
 	 *                                              e.g. if you provide the value 'https://dl_host`, it will attempt to download.
 	 *                                              a relative `src="/path/img.jpg"` from 'https://dl_host/path/img.jpg'.
 	 *
 	 * @return string|WP_Error Either a full path to a local image file, or a fully qualified HTTP path to download the image from.
 	 */
-	public function get_fully_qualified_img_import_or_download_path( $src, $folder_local_images = null, $default_image_host_and_schema = null ): string|WP_Error {
+	public function get_fully_qualified_img_import_or_download_path( $src, $folder_local_files = null, $default_image_host_and_schema = null ): string|WP_Error {
 		$img_import_path = null;
 
 		// Get the path (without host), and remove possible query params.
@@ -1354,8 +1354,8 @@ class Downloader {
 
 		// Try and get the local image file.
 		$is_local_file = false;
-		if ( $folder_local_images ) {
-			$img_local_file_path = $folder_local_images . '/' . ltrim( $src_path, '/' );
+		if ( $folder_local_files ) {
+			$img_local_file_path = $folder_local_files . '/' . ltrim( $src_path, '/' );
 			if ( $this->file_exists( $img_local_file_path ) ) {
 				$is_local_file   = true;
 				$img_import_path = $img_local_file_path;

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -151,7 +151,7 @@ class Downloader {
 					],
 					[
 						'type'        => 'assoc',
-						'name'        => 'default-image-host-and-schema',
+						'name'        => 'default-host-and-schema',
 						'description' => 'Used for relative URLs, provide th full schema and hostname where to download these from, e.g. `https://defaulthost.com`.',
 						'optional'    => true,
 						'repeating'   => false,
@@ -166,7 +166,7 @@ class Downloader {
 					[
 						'type'        => 'flag',
 						'name'        => 'do-not-download-root-relative-urls',
-						'description' => 'Unless this flag is set, the command will automatically download root-relative image URLs (e.g. `/wp-content/uploads/image.jpg`) by prepending the --default-image-host-and-schema to them.',
+						'description' => 'Unless this flag is set, the command will automatically download root-relative image URLs (e.g. `/wp-content/uploads/image.jpg`) by prepending the --default-host-and-schema to them.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -265,7 +265,7 @@ class Downloader {
 					[
 						'type'        => 'flag',
 						'name'        => 'do-not-download-root-relative-urls',
-						'description' => 'Unless this flag is set, the command will automatically download root-relative image URLs (e.g. `/wp-content/uploads/image.jpg`) by prepending the --default-image-host-and-schema to them.',
+						'description' => 'Unless this flag is set, the command will automatically download root-relative image URLs (e.g. `/wp-content/uploads/image.jpg`) by prepending the --default-host-and-schema to them.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -477,7 +477,7 @@ class Downloader {
 		$post_id_to                             = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
 		$hosts_excluded                         = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
 		$only_download_from_hosts               = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
-		$default_image_host_and_schema          = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
+		$default_host_and_schema                = isset( $assoc_args['default-host-and-schema'] ) ? rtrim( $assoc_args['default-host-and-schema'], '/' ) : null;
 		$folder_local_files                     = isset( $assoc_args['folder-local-files'] ) ? rtrim( $assoc_args['folder-local-files'], '/' ) : null;
 
 		$this->init_loggers( __FUNCTION__ );
@@ -491,6 +491,10 @@ class Downloader {
 		}
 		if ( $only_download_from_hosts && $hosts_excluded ) {
 			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When providing the `--only-download-from-hosts` param, do not use the `--exclude-hosts` at the same time.' );
+			exit;
+		}
+		if ( ! $do_not_download_root_relative_urls && ! $default_host_and_schema ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When downloading root relative URLs (will be downloaded by default unless `--do-not-download-root-relative-urls` param is used), you must also provide the `--default-host-and-schema` param.' );
 			exit;
 		}
 
@@ -590,8 +594,8 @@ class Downloader {
 
 				// Filter `src` by host.
 				if ( $only_download_from_hosts ) {
-					// Skip if relative URL host (--default-image-host-and-schema) does not match $only_download_from_hosts.
-					if ( $is_root_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
+					// Skip if relative URL host (--default-host-and-schema) does not match $only_download_from_hosts.
+					if ( $is_root_relative && ! $this->does_uri_match_host( $default_host_and_schema, $only_download_from_hosts ) ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, off target host '%s'", $src ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_protocol_relative && ! $this->does_uri_match_host( 'https:' . $src, $only_download_from_hosts ) ) {
@@ -605,7 +609,7 @@ class Downloader {
 					}
 				} elseif ( $hosts_excluded ) {
 					// Skip if relative URL host matches $hosts_excluded.
-					if ( $is_root_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
+					if ( $is_root_relative && $this->does_uri_match_host( $default_host_and_schema, $hosts_excluded ) ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, excluded host '%s'", $src ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_protocol_relative && $this->does_uri_match_host( 'https:' . $src, $hosts_excluded ) ) {
@@ -650,7 +654,7 @@ class Downloader {
 				foreach ( $srcs_ranked as $key_src_ranked => $src_ranked ) {
 
 					// Get the fully qualified import path of this ranked src file (either from local folder, or from remote URL).
-					$img_import_path = $this->get_fully_qualified_img_import_or_download_path( $src_ranked, $folder_local_files, $default_image_host_and_schema );
+					$img_import_path = $this->get_fully_qualified_img_import_or_download_path( $src_ranked, $folder_local_files, $default_host_and_schema );
 					if ( is_wp_error( $img_import_path ) ) {
 						$this->log(
 							self::LOG_OUTPUTS['CLI_AND_FILE'],
@@ -727,7 +731,7 @@ class Downloader {
 							$this->log(
 								self::LOG_OUTPUTS['CLI'],
 								LogLevel::INFO,
-								sprintf( "[Dry Run] Imported src '%s' as attachment ID '%d'", $src_ranked, is_int( $attachment_id ) ? $attachment_id : 'N/A' ),
+								sprintf( "[Dry Run] Imported src '%s' as attachment ID '%s'", $src_ranked, 'dry_run' ),
 								[
 									'post_id' => $post_id,
 									'src'     => $src_ranked,
@@ -880,7 +884,7 @@ class Downloader {
 		$post_id_to                             = isset( $assoc_args['post-id-to'] ) ? (int) $assoc_args['post-id-to'] : null;
 		$hosts_excluded                         = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
 		$only_download_from_hosts               = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
-		$default_image_host_and_schema          = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
+		$default_host_and_schema                = isset( $assoc_args['default-host-and-schema'] ) ? rtrim( $assoc_args['default-host-and-schema'], '/' ) : null;
 		$folder_local_files                     = isset( $assoc_args['folder-local-files'] ) ? rtrim( $assoc_args['folder-local-files'], '/' ) : null;
 
 		$this->init_loggers( __FUNCTION__ );
@@ -900,9 +904,13 @@ class Downloader {
 			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When providing the `--only-download-from-hosts` param, do not use the `--exclude-hosts` at the same time.' );
 			exit;
 		}
+		if ( ! $do_not_download_root_relative_urls && ! $default_host_and_schema ) {
+			$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::ERROR, '❗ When downloading root relative URLs (will be downloaded by default unless `--do-not-download-root-relative-urls` param is used), you must also provide the `--default-host-and-schema` param.' );
+			exit;
+		}
 
 		// Prepare the CSV file.
-		$csv_file = __FUNCTION__ . '__downloaded.csv';
+		$csv_file = __FUNCTION__ . '.csv';
 		if ( $this->file_exists( $csv_file ) ) {
 			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
 		}
@@ -945,7 +953,7 @@ class Downloader {
 				$this->log( self::LOG_OUTPUTS['CLI'], LogLevel::WARNING, sprintf( 'No post content in post ID %d, skipping...', $post_id ) );
 				continue;
 			}
-			MemoryCleanupHook::cleanup( 0, $key_post + 1, 10 );
+			MemoryCleanupHook::cleanup();
 
 			// Get all URLs with extensions from HTML.
 			$urls_all        = $this->get_all_urls_from_html( $post_content );
@@ -989,8 +997,8 @@ class Downloader {
 
 				// Filter URL by host.
 				if ( $only_download_from_hosts ) {
-					// Skip if root-relative URL host (--default-image-host-and-schema) does not match $only_download_from_hosts.
-					if ( $is_root_relative && ! $this->does_uri_match_host( $default_image_host_and_schema, $only_download_from_hosts ) ) {
+					// Skip if root-relative URL host (--default-host-and-schema) does not match $only_download_from_hosts.
+					if ( $is_root_relative && ! $this->does_uri_match_host( $default_host_and_schema, $only_download_from_hosts ) ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_protocol_relative && ! $this->does_uri_match_host( 'https:' . $url, $only_download_from_hosts ) ) {
@@ -1003,7 +1011,7 @@ class Downloader {
 					}
 				} elseif ( $hosts_excluded ) {
 					// Skip if root-relative URL host matches $hosts_excluded.
-					if ( $is_root_relative && $this->does_uri_match_host( $default_image_host_and_schema, $hosts_excluded ) ) {
+					if ( $is_root_relative && $this->does_uri_match_host( $default_host_and_schema, $hosts_excluded ) ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping root-relative URL, excluded host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					} elseif ( $is_protocol_relative && $this->does_uri_match_host( 'https:' . $url, $hosts_excluded ) ) {
@@ -1023,7 +1031,7 @@ class Downloader {
 				}
 
 				// Get the fully qualified import path of this file (either from local folder, or from remote URL).
-				$file_import_path = $this->get_fully_qualified_img_import_or_download_path( $url, $folder_local_files, $default_image_host_and_schema );
+				$file_import_path = $this->get_fully_qualified_img_import_or_download_path( $url, $folder_local_files, $default_host_and_schema );
 				if ( is_wp_error( $file_import_path ) ) {
 					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Error getting file path for '%s', error: %s", $url, $file_import_path->get_error_message() ), [ 'post_id' => $post_id ] );
 					continue;
@@ -1034,16 +1042,19 @@ class Downloader {
 				$filename_parts = pathinfo( $basename );
 				$title          = $filename_parts['filename'];
 
+				// Clean up memory.
+				MemoryCleanupHook::cleanup();
+
 				// Download the file.
-				$attachment_id = ! $dry_run ? $attachments_logic->import_external_file( $file_import_path, $title, null, null, null, $post_id ) : 'N/A';
+				$attachment_id = ! $dry_run ? $attachments_logic->import_external_file( $file_import_path, $title, null, null, null, $post_id ) : 'dry_run';
 				if ( is_wp_error( $attachment_id ) ) {
 					// CSV, log error.
-					fputcsv( $csv_file_handle, [ $post_id, $url, sprintf( "Error downloading '%s': %s", $file_import_path, $attachment_id->get_error_message() ), '', '' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+					fputcsv( $csv_file_handle, [ $post_id, $url, sprintf( "Error downloading '%s': (%s) %s", $file_import_path, $attachment_id->get_error_code(), $attachment_id->get_error_message() ), '', '' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 					$this->log(
 						self::LOG_OUTPUTS['CLI_AND_FILE'],
 						LogLevel::ERROR,
-						sprintf( "❗ Error importing file '%s', error: %s", $file_import_path, $attachment_id->get_error_message() ),
+						sprintf( "❗ Error importing file '%s', error: (%s) %s", $file_import_path, $attachment_id->get_error_code(), $attachment_id->get_error_message() ),
 						[
 							'url'     => $url,
 							'post_id' => $post_id,
@@ -1063,7 +1074,7 @@ class Downloader {
 				);
 
 				// Replace $url with imported URL.
-				$url_imported         = ! $dry_run ? wp_get_attachment_url( $attachment_id ) : 'n/a';
+				$url_imported         = ! $dry_run ? wp_get_attachment_url( $attachment_id ) : 'dry_run';
 				$post_content_updated = str_replace( $url, $url_imported, $post_content_updated );
 
 				// CSV, add the imported file to the CSV file.
@@ -1334,15 +1345,15 @@ class Downloader {
 	 * Returns a full image path to import or download from. If a local image file is available, returns the full path to the file,
 	 * or else returns a fully qualified HTTP path to download from.
 	 *
-	 * @param string $src                           Img `src` URI.
-	 * @param string $folder_local_files            Path to local folder where image files can be found at.
-	 * @param string $default_image_host_and_schema Default schema+host used to download relative referenced URLs.
-	 *                                              e.g. if you provide the value 'https://dl_host`, it will attempt to download.
-	 *                                              a relative `src="/path/img.jpg"` from 'https://dl_host/path/img.jpg'.
+	 * @param string $src                     Img `src` URI.
+	 * @param string $folder_local_files      Path to local folder where image files can be found at.
+	 * @param string $default_host_and_schema Default schema+host used to download relative referenced URLs.
+	 *                                        e.g. if you provide the value 'https://dl_host`, it will attempt to download.
+	 *                                        a relative `src="/path/img.jpg"` from 'https://dl_host/path/img.jpg'.
 	 *
 	 * @return string|WP_Error Either a full path to a local image file, or a fully qualified HTTP path to download the image from.
 	 */
-	public function get_fully_qualified_img_import_or_download_path( $src, $folder_local_files = null, $default_image_host_and_schema = null ): string|WP_Error {
+	public function get_fully_qualified_img_import_or_download_path( $src, $folder_local_files = null, $default_host_and_schema = null ): string|WP_Error {
 		$img_import_path = null;
 
 		// Get the path (without host), and remove possible query params.
@@ -1372,7 +1383,7 @@ class Downloader {
 		 * Handles three types of `src`s like this:
 		 *      - an absolute HTTP URL, e.g. 'https://host.com/img.jpg'
 		 *      - a protocol-relative URL, e.g. '//cdn.host.com/img.jpg'
-		 *      - a relative reference from root, e.g. '/segment/img.jpg', and uses the `--default-image-host-and-schema` to try
+		 *      - a relative reference from root, e.g. '/segment/img.jpg', and uses the `--default-host-and-schema` to try
 		 *        and download it
 		 */
 		$is_absolute          = $this->is_url_absolute( $src );
@@ -1387,15 +1398,15 @@ class Downloader {
 			// Transform protocol-relative URL to absolute URL.
 			$img_import_path = 'https:' . $src;
 		} elseif ( $is_root_relative ) {
-			if ( ! $default_image_host_and_schema ) {
+			if ( ! $default_host_and_schema ) {
 				return new WP_Error(
 					'no_default_host_provided',
-					sprintf( "Could not download relative src '%s' since --default-image-host-and-schema was not provided.", esc_url( $src ) ),
+					sprintf( "Could not download relative src '%s' since --default-host-and-schema was not provided.", esc_url( $src ) ),
 					wp_json_encode( [ 'src' => $src ] )
 				);
 			}
-			// Use the `--default-image-host-and-schema` to try and download a root-relative URL.
-			$img_import_path = $default_image_host_and_schema
+			// Use the `--default-host-and-schema` to try and download a root-relative URL.
+			$img_import_path = $default_host_and_schema
 				. ( ( 0 !== strpos( strtolower( $src ), '/' ) ) ? '/' : '' )
 				. $src;
 		} else {

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -258,7 +258,7 @@ class Downloader {
 					[
 						'type'        => 'assoc',
 						'name'        => 'extensions',
-						'description' => 'Extensions to download. E.g. --extensions=pdf,docx,xlsx,pptx',
+						'description' => 'Extensions to download, case insensitive. E.g. --extensions=pdf,docx,xlsx,pptx',
 						'optional'    => false,
 						'repeating'   => false,
 					],
@@ -364,12 +364,12 @@ class Downloader {
 		}
 		
 		// Prepare the CSV file.
-		$csv_file = __FUNCTION__ . '__urls' . ( $include_non_image_urls ? '_all' : '_images' ) . '.csv';
+		$csv_file = __FUNCTION__ . '.csv';
 		if ( $this->file_exists( $csv_file ) ) {
 			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
 		}
 		$csv_file_handle = fopen( $csv_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
-		fputcsv( $csv_file_handle, [ 'post_id', 'hostname', 'extension', 'url' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+		fputcsv( $csv_file_handle, [ 'post_id', 'hostname', 'extension', 'url' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 		// Get post IDs.
 		$post_ids = $this->get_post_ids( $post_ids_specific, $post_id_from, $post_id_to, $post_types, $post_statuses );
@@ -390,7 +390,6 @@ class Downloader {
 
 			$post_content = $this->get_post_content( $post_id );
 			if ( ! $post_content ) {
-				$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::WARNING, sprintf( '⚠️ Could not fetch content for post ID %d', $post_id ) );
 				continue;
 			}
 
@@ -420,7 +419,7 @@ class Downloader {
 					$url_check = 'https:' . $url;
 				} else {
 					// Unsupported URL, like `src="data:image/svg+xml;base64"` or invalid URLs.
-					fputcsv( $csv_file_handle, [ $post_id, 'N/A', 'N/A', $url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+					fputcsv( $csv_file_handle, [ $post_id, '', '', $url ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 					continue;
 				}
 
@@ -432,7 +431,7 @@ class Downloader {
 				$extension = $this->get_url_extension( $url_check );
 
 				// Add to CSV.
-				fputcsv( $csv_file_handle, [ $post_id, ! empty( $hostname ) ? $hostname : 'N/A', ! empty( $extension ) ? $extension : 'NO_EXTENSION', $url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+				fputcsv( $csv_file_handle, [ $post_id, $hostname, $extension, $url, ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 				// Add to quick CLI output variable.
 				if ( ! empty( $hostname ) && ! in_array( $hostname, $cli_quick_output['hostnames'] ) ) {
@@ -451,7 +450,7 @@ class Downloader {
 		if ( count( $cli_quick_output['hostnames'] ) > 0 ) {
 			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '- %s', implode( "\n- ", $cli_quick_output['hostnames'] ) ) );
 		}
-		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total URL extensions', count( $cli_quick_output['extensions'] ) ) );
+		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total URL extensions -- note that technically extension is everything after the last dot, so use the following list to determine which ones are valid ', count( $cli_quick_output['extensions'] ) ) );
 		if ( count( $cli_quick_output['extensions'] ) > 0 ) {
 			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '- %s', implode( ', ', $cli_quick_output['extensions'] ) ) );
 		}
@@ -501,7 +500,7 @@ class Downloader {
 			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
 		}
 		$csv_file_handle = fopen( $csv_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
-		fputcsv( $csv_file_handle, [ 'post_id', 'url_original', 'attachment_id', 'url_downloaded' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+		fputcsv( $csv_file_handle, [ 'post_id', 'url_original', 'attachment_id', 'url_downloaded' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 		global $wpdb;
 		$time_start        = microtime( true );
@@ -682,7 +681,7 @@ class Downloader {
 							$attachment_id = $attachments_logic->import_external_file( $img_import_path, $title_to_use, null, null, $alt_to_use, $post_id );
 							if ( is_wp_error( $attachment_id ) ) {
 								// CSV, log error.
-								fputcsv( $csv_file_handle, [ $post_id, $src_ranked, sprintf( 'ERROR: %s', $attachment_id->get_error_message() ), '' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+								fputcsv( $csv_file_handle, [ $post_id, $src_ranked, sprintf( 'ERROR: %s', $attachment_id->get_error_message() ), '' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 								$this->log(
 									self::LOG_OUTPUTS['CLI_AND_FILE'],
@@ -719,7 +718,7 @@ class Downloader {
 							}
 
 							// CSV, add the imported image to the CSV file.
-							fputcsv( $csv_file_handle, [ $post_id, $src_ranked, $attachment_id, $attachment_url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+							fputcsv( $csv_file_handle, [ $post_id, $src_ranked, $attachment_id, $attachment_url ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 						} else {
 							// Dry run.
 							$imported        = true;
@@ -766,7 +765,7 @@ class Downloader {
 							// Handle error.
 							if ( is_wp_error( $downloaded ) ) {
 								// CSV, log error.
-								fputcsv( $csv_file_handle, [ $post_id, $src_ranked, sprintf( 'ERROR: %s', $downloaded->get_error_message() ), '' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+								fputcsv( $csv_file_handle, [ $post_id, $src_ranked, sprintf( 'ERROR: %s', $downloaded->get_error_message() ), '' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 								$this->log(
 									self::LOG_OUTPUTS['CLI_AND_FILE'],
@@ -789,7 +788,7 @@ class Downloader {
 							}
 							
 							// CSV, add the imported image to the CSV file.
-							fputcsv( $csv_file_handle, [ $post_id, $src_ranked, '', $downloaded_url ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+							fputcsv( $csv_file_handle, [ $post_id, $src_ranked, '', $downloaded_url ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 							$this->log(
 								self::LOG_OUTPUTS['CLI_AND_FILE'],
@@ -908,7 +907,7 @@ class Downloader {
 			unlink( $csv_file ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink.
 		}
 		$csv_file_handle = fopen( $csv_file, 'w' ); // phpcs:ignore -- WordPress.WP.AlternativeFunctions.file_system_operations_fopen.
-		fputcsv( $csv_file_handle, [ 'post_id', 'url_original', 'attachment_id', 'url_downloaded' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+		fputcsv( $csv_file_handle, [ 'post_id', 'url_original', 'result', 'attachment_id', 'url_downloaded' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 		global $wpdb;
 		$time_start        = microtime( true );
@@ -1039,7 +1038,7 @@ class Downloader {
 				$attachment_id = ! $dry_run ? $attachments_logic->import_external_file( $file_import_path, $title, null, null, null, $post_id ) : 'N/A';
 				if ( is_wp_error( $attachment_id ) ) {
 					// CSV, log error.
-					fputcsv( $csv_file_handle, [ $post_id, $url, sprintf( 'ERROR: %s', $attachment_id->get_error_message() ), '' ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+					fputcsv( $csv_file_handle, [ $post_id, $url, sprintf( "Error downloading '%s': %s", $file_import_path, $attachment_id->get_error_message() ), '', '' ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 
 					$this->log(
 						self::LOG_OUTPUTS['CLI_AND_FILE'],
@@ -1068,7 +1067,7 @@ class Downloader {
 				$post_content_updated = str_replace( $url, $url_imported, $post_content_updated );
 
 				// CSV, add the imported file to the CSV file.
-				fputcsv( $csv_file_handle, [ $post_id, $url, $attachment_id, $url_imported ] ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+				fputcsv( $csv_file_handle, [ $post_id, $url, 'success', $attachment_id, $url_imported ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 			}
 
 			// Update the Post content.

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -193,7 +193,7 @@ class Downloader {
 					],
 					[
 						'type'        => 'assoc',
-						'name'        => 'folder-local-images',
+						'name'        => 'folder-local-files',
 						'description' => 'Local folder which contains the image files. Images which are found here, get imported from local files, otherwise they get downloaded via HTTP.',
 						'optional'    => true,
 						'repeating'   => false,
@@ -477,7 +477,7 @@ class Downloader {
 		$hosts_excluded                         = isset( $assoc_args['exclude-hosts'] ) ? explode( ',', $assoc_args['exclude-hosts'] ) : null;
 		$only_download_from_hosts               = isset( $assoc_args['only-download-from-hosts'] ) ? explode( ',', $assoc_args['only-download-from-hosts'] ) : null;
 		$default_image_host_and_schema          = isset( $assoc_args['default-image-host-and-schema'] ) ? rtrim( $assoc_args['default-image-host-and-schema'], '/' ) : null;
-		$folder_local_images                    = isset( $assoc_args['folder-local-images'] ) ? rtrim( $assoc_args['folder-local-images'], '/' ) : null;
+		$folder_local_files                     = isset( $assoc_args['folder-local-files'] ) ? rtrim( $assoc_args['folder-local-files'], '/' ) : null;
 
 		$this->init_loggers( __FUNCTION__ );
 		if ( ( $post_ids_specific && $post_id_from ) || ( $post_ids_specific && $post_id_to ) ) {
@@ -649,7 +649,7 @@ class Downloader {
 				foreach ( $srcs_ranked as $key_src_ranked => $src_ranked ) {
 
 					// Get the fully qualified import path of this ranked src file (either from local folder, or from remote URL).
-					$img_import_path = $this->get_fully_qualified_img_import_or_download_path( $src_ranked, $folder_local_images, $default_image_host_and_schema );
+					$img_import_path = $this->get_fully_qualified_img_import_or_download_path( $src_ranked, $folder_local_files, $default_image_host_and_schema );
 					if ( is_wp_error( $img_import_path ) ) {
 						$this->log(
 							self::LOG_OUTPUTS['CLI_AND_FILE'],
@@ -1366,14 +1366,11 @@ class Downloader {
 		}
 
 		/**
-		 * Handles four types of `src`s like this:
+		 * Handles three types of `src`s like this:
 		 *      - an absolute HTTP URL, e.g. 'https://host.com/img.jpg'
 		 *      - a protocol-relative URL, e.g. '//cdn.host.com/img.jpg'
 		 *      - a relative reference from root, e.g. '/segment/img.jpg', and uses the `--default-image-host-and-schema` to try
 		 *        and download it
-		 *      - a relative reference without the beginning `/`, e.g. 'segment/img.jpg'. Although this could also be a different
-		 *        kind of `src`, e.g. `src="data:image/svg+xml;base64..."`, it still tries to transform it to a fully qualified
-		 *        URL by using the `--default-image-host-and-schema` to download from.
 		 */
 		$is_absolute          = $this->is_url_absolute( $src );
 		$is_root_relative     = $this->is_url_root_relative( $src );

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -794,10 +794,10 @@ class Test_Downloader extends WP_UnitTestCase {
 				'Download from "https://example.com/file.pdf" or visit "http://another.com/page".',
 				[ 'https://example.com/file.pdf', 'http://another.com/page' ],
 			],
-			// Text with URLs and other content.
+			// Text with URLs and other content. Note, allowing dot to be a part of the URL because technically it's a valid URL character.
 			[
 				'Lorem ipsum dolor sit amet. Visit https://example.com/page for more info. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Check http://another.com/resource.',
-				[ 'https://example.com/page', 'http://another.com/resource' ],
+				[ 'https://example.com/page', 'http://another.com/resource.' ],
 			],
 			// Text with URLs with query parameters.
 			[
@@ -809,15 +809,15 @@ class Test_Downloader extends WP_UnitTestCase {
 				'Go to https://example.com/page#section for the specific section.',
 				[ 'https://example.com/page#section' ],
 			],
-			// Text with mixed URL types (should only extract absolute).
+			// Text with mixed URL types (should only extract absolute). Note, allowing comma and dot to be a part of the URL because technically they are valid URL characters.
 			[
 				'Visit https://example.com/page, /relative/path, //protocol-relative.com/path, and http://another.com/resource.',
-				[ 'https://example.com/page', 'http://another.com/resource' ],
+				[ 'https://example.com/page,', 'http://another.com/resource.' ],
 			],
-			// Text with source-relative URLs and protocol-relative URLs.
+			// Text with source-relative URLs and protocol-relative URLs. Note, allowing dot to be a part of the URL because technically it's a valid URL character.
 			[
 				'Visit https://example.com/page or /relative/path or //protocol-relative.com/path or http://another.com/resource.',
-				[ 'https://example.com/page', 'http://another.com/resource' ],
+				[ 'https://example.com/page', 'http://another.com/resource.' ],
 			],
 		];
 	}

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -225,6 +225,123 @@ class Test_Downloader extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the `get_all_img_srcs_from_html` function.
+	 *
+	 * @dataProvider providerGetAllImgSrcsFromHtml
+	 *
+	 * @param string $html            The HTML content to parse.
+	 * @param array  $result_expected The expected array of image src URLs.
+	 */
+	public function test_get_all_img_srcs_from_html( $html, $result_expected ) {
+		$result_actual = $this->downloader->get_all_img_srcs_from_html( $html );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `get_all_urls_from_html` function.
+	 *
+	 * @dataProvider providerGetAllUrlsFromHtml
+	 *
+	 * @param string $html            The HTML content to parse.
+	 * @param array  $result_expected The expected array of URLs.
+	 */
+	public function test_get_all_urls_from_html( $html, $result_expected ) {
+		$result_actual = $this->downloader->get_all_urls_from_html( $html );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `get_urls_from_srcset` function.
+	 *
+	 * @dataProvider providerGetUrlsFromSrcset
+	 *
+	 * @param string $srcset          The srcset attribute value.
+	 * @param array  $result_expected The expected array of URLs.
+	 */
+	public function test_get_urls_from_srcset( $srcset, $result_expected ) {
+		$result_actual = $this->downloader->get_urls_from_srcset( $srcset );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `get_absolute_urls_from_text` function.
+	 *
+	 * @dataProvider providerGetAbsoluteUrlsFromText
+	 *
+	 * @param string $text            The text content to parse.
+	 * @param array  $result_expected The expected array of absolute URLs.
+	 */
+	public function test_get_absolute_urls_from_text( $text, $result_expected ) {
+		$result_actual = $this->downloader->get_absolute_urls_from_text( $text );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `get_url_extension` function.
+	 *
+	 * @dataProvider providerGetUrlExtension
+	 *
+	 * @param string $url             The URL to extract extension from.
+	 * @param string $result_expected The expected file extension.
+	 */
+	public function test_get_url_extension( $url, $result_expected ) {
+		$result_actual = $this->downloader->get_url_extension( $url );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `is_url_absolute` function.
+	 *
+	 * @dataProvider providerIsUrlAbsolute
+	 *
+	 * @param string $url             The URL to test.
+	 * @param bool   $result_expected The expected result.
+	 */
+	public function test_is_url_absolute( $url, $result_expected ) {
+		$result_actual = $this->downloader->is_url_absolute( $url );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `is_url_root_relative` function.
+	 *
+	 * @dataProvider providerIsUrlRootRelative
+	 *
+	 * @param string $url             The URL to test.
+	 * @param bool   $result_expected The expected result.
+	 */
+	public function test_is_url_root_relative( $url, $result_expected ) {
+		$result_actual = $this->downloader->is_url_root_relative( $url );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `is_url_protocol_relative` function.
+	 *
+	 * @dataProvider providerIsUrlProtocolRelative
+	 *
+	 * @param string $url             The URL to test.
+	 * @param bool   $result_expected The expected result.
+	 */
+	public function test_is_url_protocol_relative( $url, $result_expected ) {
+		$result_actual = $this->downloader->is_url_protocol_relative( $url );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
+	 * Tests the `is_url_valid` function.
+	 *
+	 * @dataProvider providerIsUrlValid
+	 *
+	 * @param string $url             The URL to test.
+	 * @param bool   $result_expected The expected result.
+	 */
+	public function test_is_url_valid( $url, $result_expected ) {
+		$result_actual = $this->downloader->is_url_valid( $url );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
 	 * Creates a partial mock of the Downloader class, and mocks the `file_exists` method with expected input argument and response.
 	 * In case of a different input argument, mock will return null.
 	 *
@@ -252,15 +369,17 @@ class Test_Downloader extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Changes object's method accessibility to public.
+	 * Changes object's method accessibility to public and returns the reflection method.
 	 *
 	 * @param object $class_object Object whose method accessibility is changed.
 	 * @param string $method_name  Method name.
+	 * @return \ReflectionMethod The reflection method object.
 	 */
 	private function make_object_method_public( $class_object, $method_name ) {
 		$reflector = new ReflectionObject( $class_object );
 		$method    = $reflector->getMethod( $method_name );
 		$method->setAccessible( true );
+		return $method;
 	}
 
 	/**
@@ -479,6 +598,628 @@ class Test_Downloader extends WP_UnitTestCase {
 					'title'                => '',
 					'alt'                  => '',
 				],
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_get_all_img_srcs_from_html.
+	 *
+	 * @return array[]
+	 */
+	public function providerGetAllImgSrcsFromHtml() {
+		return [
+			// Empty HTML.
+			[
+				'',
+				[],
+			],
+			// HTML with no images.
+			[
+				'<div>Some text</div>',
+				[],
+			],
+			// Single image with src.
+			[
+				'<img src="https://example.com/image.jpg" alt="Test">',
+				[ 'https://example.com/image.jpg' ],
+			],
+			// Multiple images with src.
+			[
+				'<img src="https://example.com/image1.jpg" alt="Test1"><img src="https://example.com/image2.png" alt="Test2">',
+				[ 'https://example.com/image1.jpg', 'https://example.com/image2.png' ],
+			],
+			// Image with srcset.
+			[
+				'<img src="https://example.com/image.jpg" srcset="https://example.com/image-300w.jpg 300w, https://example.com/image-600w.jpg 600w" alt="Test">',
+				[ 'https://example.com/image.jpg', 'https://example.com/image-300w.jpg', 'https://example.com/image-600w.jpg' ],
+			],
+			// Image with data-srcset.
+			[
+				'<img src="https://example.com/image.jpg" data-srcset="https://example.com/image-300w.jpg 300w, https://example.com/image-600w.jpg 600w" alt="Test">',
+				[ 'https://example.com/image.jpg', 'https://example.com/image-300w.jpg', 'https://example.com/image-600w.jpg' ],
+			],
+			// Image with both srcset and data-srcset.
+			[
+				'<img src="https://example.com/image.jpg" srcset="https://example.com/image-300w.jpg 300w" data-srcset="https://example.com/image-600w.jpg 600w" alt="Test">',
+				[ 'https://example.com/image.jpg', 'https://example.com/image-300w.jpg', 'https://example.com/image-600w.jpg' ],
+			],
+			// Image with empty src.
+			[
+				'<img src="" alt="Test">',
+				[],
+			],
+			// Image with no src attribute.
+			[
+				'<img alt="Test">',
+				[],
+			],
+			// Complex HTML with mixed content.
+			[
+				'<div><p>Text</p><img src="https://example.com/image1.jpg" alt="Test1"><span>More text</span><img src="https://example.com/image2.png" srcset="https://example.com/image2-300w.png 300w" alt="Test2"></div>',
+				[ 'https://example.com/image1.jpg', 'https://example.com/image2.png', 'https://example.com/image2-300w.png' ],
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_get_all_urls_from_html.
+	 *
+	 * @return array[]
+	 */
+	public function providerGetAllUrlsFromHtml() {
+		return [
+			// Empty HTML.
+			[
+				'',
+				[],
+			],
+			// HTML with no URLs.
+			[
+				'<div>Some text</div>',
+				[],
+			],
+			// HTML with various URL attributes.
+			[
+				'<a href="https://example.com/link">Link</a><img src="https://example.com/image.jpg" alt="Test">',
+				[ 'https://example.com/link', 'https://example.com/image.jpg' ],
+			],
+			// HTML with srcset URLs.
+			[
+				'<img src="https://example.com/image.jpg" srcset="https://example.com/image-300w.jpg 300w, https://example.com/image-600w.jpg 600w" alt="Test">',
+				[ 'https://example.com/image.jpg', 'https://example.com/image-300w.jpg', 'https://example.com/image-600w.jpg' ],
+			],
+			// HTML with data attributes.
+			[
+				'<img data-src="https://example.com/lazy.jpg" data-background="https://example.com/bg.jpg" alt="Test">',
+				[ 'https://example.com/lazy.jpg', 'https://example.com/bg.jpg' ],
+			],
+			// HTML with video poster.
+			[
+				'<video poster="https://example.com/poster.jpg" src="https://example.com/video.mp4"></video>',
+				[ 'https://example.com/poster.jpg', 'https://example.com/video.mp4' ],
+			],
+			// HTML with absolute URLs in text content.
+			[
+				'<div>Check out https://example.com/page and http://another.com/resource</div>',
+				[ 'https://example.com/page', 'http://another.com/resource' ],
+			],
+			// Complex HTML with mixed content.
+			[
+				'<div><a href="https://example.com/link">Link</a><img src="https://example.com/image.jpg" srcset="https://example.com/image-300w.jpg 300w" alt="Test"><p>Visit https://example.com/page for more info</p></div>',
+				[ 'https://example.com/link', 'https://example.com/image.jpg', 'https://example.com/image-300w.jpg', 'https://example.com/page' ],
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_get_urls_from_srcset.
+	 *
+	 * @return array[]
+	 */
+	public function providerGetUrlsFromSrcset() {
+		return [
+			// Empty srcset.
+			[
+				'',
+				[],
+			],
+			// Single URL without descriptor.
+			[
+				'https://example.com/image.jpg',
+				[ 'https://example.com/image.jpg' ],
+			],
+			// Single URL with width descriptor.
+			[
+				'https://example.com/image-300w.jpg 300w',
+				[ 'https://example.com/image-300w.jpg' ],
+			],
+			// Single URL with height descriptor.
+			[
+				'https://example.com/image-600h.jpg 600h',
+				[ 'https://example.com/image-600h.jpg' ],
+			],
+			// Multiple URLs with descriptors.
+			[
+				'https://example.com/image-300w.jpg 300w, https://example.com/image-600w.jpg 600w',
+				[ 'https://example.com/image-300w.jpg', 'https://example.com/image-600w.jpg' ],
+			],
+			// Multiple URLs with mixed descriptors.
+			[
+				'https://example.com/image-300w.jpg 300w, https://example.com/image-600h.jpg 600h, https://example.com/image.jpg 1x',
+				[ 'https://example.com/image-300w.jpg', 'https://example.com/image-600h.jpg', 'https://example.com/image.jpg' ],
+			],
+			// URLs with extra whitespace.
+			[
+				'  https://example.com/image-300w.jpg  300w  ,  https://example.com/image-600w.jpg  600w  ',
+				[ 'https://example.com/image-300w.jpg', 'https://example.com/image-600w.jpg' ],
+			],
+			// URLs with query parameters.
+			[
+				'https://example.com/image-300w.jpg?v=1 300w, https://example.com/image-600w.jpg?v=2 600w',
+				[ 'https://example.com/image-300w.jpg?v=1', 'https://example.com/image-600w.jpg?v=2' ],
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_get_absolute_urls_from_text.
+	 *
+	 * @return array[]
+	 */
+	public function providerGetAbsoluteUrlsFromText() {
+		return [
+			// Empty text.
+			[
+				'',
+				[],
+			],
+			// Text with no URLs.
+			[
+				'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+				[],
+			],
+			// Text with absolute URLs.
+			[
+				'Visit https://example.com/page for more information.',
+				[ 'https://example.com/page' ],
+			],
+			// Text with multiple absolute URLs.
+			[
+				'Check out https://example.com/page and http://another.com/resource for details.',
+				[ 'https://example.com/page', 'http://another.com/resource' ],
+			],
+			// Text with URLs in quotes.
+			[
+				'Download from "https://example.com/file.pdf" or visit "http://another.com/page".',
+				[ 'https://example.com/file.pdf', 'http://another.com/page' ],
+			],
+			// Text with URLs and other content.
+			[
+				'Lorem ipsum dolor sit amet. Visit https://example.com/page for more info. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Check http://another.com/resource.',
+				[ 'https://example.com/page', 'http://another.com/resource' ],
+			],
+			// Text with URLs with query parameters.
+			[
+				'Visit https://example.com/page?param=value&other=123 for details.',
+				[ 'https://example.com/page?param=value&other=123' ],
+			],
+			// Text with URLs with fragments.
+			[
+				'Go to https://example.com/page#section for the specific section.',
+				[ 'https://example.com/page#section' ],
+			],
+			// Text with mixed URL types (should only extract absolute).
+			[
+				'Visit https://example.com/page, /relative/path, //protocol-relative.com/path, and http://another.com/resource.',
+				[ 'https://example.com/page', 'http://another.com/resource' ],
+			],
+			// Text with source-relative URLs and protocol-relative URLs.
+			[
+				'Visit https://example.com/page or /relative/path or //protocol-relative.com/path or http://another.com/resource.',
+				[ 'https://example.com/page', 'http://another.com/resource' ],
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_get_url_extension.
+	 *
+	 * @return array[]
+	 */
+	public function providerGetUrlExtension() {
+		return [
+			// Absolute URLs.
+			[
+				'https://example.com/image.jpg',
+				'jpg',
+			],
+			[
+				'https://example.com/path/to/image.png',
+				'png',
+			],
+			[
+				'https://example.com/file.pdf',
+				'pdf',
+			],
+			[
+				'https://example.com/document.docx',
+				'docx',
+			],
+			// Root-relative URLs.
+			[
+				'/wp-content/uploads/image.jpg',
+				'jpg',
+			],
+			[
+				'/path/to/file.png',
+				'png',
+			],
+			// Protocol-relative URLs.
+			[
+				'//cdn.example.com/image.jpg',
+				'jpg',
+			],
+			[
+				'//static.example.com/file.png',
+				'png',
+			],
+			// URLs with query parameters.
+			[
+				'https://example.com/image.jpg?v=1&size=large',
+				'jpg',
+			],
+			[
+				'/path/to/file.png?width=300&height=200',
+				'png',
+			],
+			// URLs with fragments.
+			[
+				'https://example.com/image.jpg#section',
+				'jpg',
+			],
+			[
+				'/path/to/file.png#top',
+				'png',
+			],
+			// URLs with both query and fragment.
+			[
+				'https://example.com/image.jpg?v=1#section',
+				'jpg',
+			],
+			// URLs without extension.
+			[
+				'https://example.com/page',
+				'',
+			],
+			[
+				'/path/to/page',
+				'',
+			],
+			// URLs ending with slash.
+			[
+				'https://example.com/path/',
+				'',
+			],
+			[
+				'/path/to/directory/',
+				'',
+			],
+			// URLs with multiple dots.
+			[
+				'https://example.com/file.name.jpg',
+				'jpg',
+			],
+			[
+				'/path/to/file.name.png',
+				'png',
+			],
+			// URLs with uppercase extensions.
+			[
+				'https://example.com/image.JPG',
+				'JPG',
+			],
+			[
+				'/path/to/file.PNG',
+				'PNG',
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_is_url_absolute.
+	 *
+	 * @return array[]
+	 */
+	public function providerIsUrlAbsolute() {
+		return [
+			// Valid absolute URLs.
+			[
+				'https://example.com/page',
+				true,
+			],
+			[
+				'http://example.com/page',
+				true,
+			],
+			[
+				'HTTPS://EXAMPLE.COM/PAGE',
+				true,
+			],
+			[
+				'HTTP://EXAMPLE.COM/PAGE',
+				true,
+			],
+			// Non-absolute URLs.
+			[
+				'/relative/path',
+				false,
+			],
+			[
+				'//protocol-relative.com/path',
+				false,
+			],
+			[
+				'relative/path',
+				false,
+			],
+			[
+				'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PC9zdmc+',
+				false,
+			],
+			[
+				'mailto:user@example.com',
+				false,
+			],
+			[
+				'tel:+1234567890',
+				false,
+			],
+			// Edge cases.
+			[
+				'',
+				false,
+			],
+			[
+				'   https://example.com/page   ',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_is_url_root_relative.
+	 *
+	 * @return array[]
+	 */
+	public function providerIsUrlRootRelative() {
+		return [
+			// Valid root-relative URLs.
+			[
+				'/path/to/page',
+				true,
+			],
+			[
+				'/image.jpg',
+				true,
+			],
+			[
+				'/',
+				true,
+			],
+			[
+				'/path/with/query?param=value',
+				true,
+			],
+			[
+				'/path/with/fragment#section',
+				true,
+			],
+			// Non-root-relative URLs.
+			[
+				'https://example.com/page',
+				false,
+			],
+			[
+				'http://example.com/page',
+				false,
+			],
+			[
+				'//protocol-relative.com/path',
+				false,
+			],
+			[
+				'relative/path',
+				false,
+			],
+			[
+				'path/without/leading/slash',
+				false,
+			],
+			[
+				'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PC9zdmc+',
+				false,
+			],
+			// Edge cases.
+			[
+				'',
+				false,
+			],
+			[
+				'   /path/to/page   ',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_is_url_protocol_relative.
+	 *
+	 * @return array[]
+	 */
+	public function providerIsUrlProtocolRelative() {
+		return [
+			// Valid protocol-relative URLs.
+			[
+				'//example.com/page',
+				true,
+			],
+			[
+				'//cdn.example.com/image.jpg',
+				true,
+			],
+			[
+				'//static.example.com/path/to/file.png',
+				true,
+			],
+			[
+				'//example.com/path/with/query?param=value',
+				true,
+			],
+			[
+				'//example.com/path/with/fragment#section',
+				true,
+			],
+			// Non-protocol-relative URLs.
+			[
+				'https://example.com/page',
+				false,
+			],
+			[
+				'http://example.com/page',
+				false,
+			],
+			[
+				'/relative/path',
+				false,
+			],
+			[
+				'relative/path',
+				false,
+			],
+			[
+				'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PC9zdmc+',
+				false,
+			],
+			// Edge cases.
+			[
+				'',
+				false,
+			],
+			[
+				'   //example.com/page   ',
+				true,
+			],
+			[
+				'///example.com/page',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_is_url_valid.
+	 *
+	 * @return array[]
+	 */
+	public function providerIsUrlValid() {
+		return [
+			// Valid absolute URLs.
+			[
+				'https://example.com/page',
+				true,
+			],
+			[
+				'http://example.com/page',
+				true,
+			],
+			[
+				'https://example.com/path/to/page?param=value#section',
+				true,
+			],
+			[
+				'http://subdomain.example.com:8080/path',
+				true,
+			],
+			// Valid root-relative URLs.
+			[
+				'/path/to/page',
+				true,
+			],
+			[
+				'/image.jpg',
+				true,
+			],
+			[
+				'/path/with/query?param=value',
+				true,
+			],
+			[
+				'/path/with/fragment#section',
+				true,
+			],
+			// Valid protocol-relative URLs.
+			[
+				'//example.com/page',
+				true,
+			],
+			[
+				'//cdn.example.com/image.jpg',
+				true,
+			],
+			[
+				'//example.com/path/with/query?param=value',
+				true,
+			],
+			// Invalid URLs.
+			[
+				'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PC9zdmc+',
+				false,
+			],
+			[
+				'mailto:user@example.com',
+				false,
+			],
+			[
+				'tel:+1234567890',
+				false,
+			],
+			[
+				'relative/path',
+				false,
+			],
+			[
+				'path/without/leading/slash',
+				false,
+			],
+			[
+				'ftp://example.com/file',
+				false,
+			],
+			[
+				'http://example.com:invalid/file',
+				false,
+			],
+			[
+				'https://example.com:99999/file',
+				false,
+			],
+			// Edge cases.
+			[
+				'',
+				false,
+			],
+			[
+				'   https://example.com/page   ',
+				true,
+			],
+			[
+				'   /path/to/page   ',
+				true,
+			],
+			[
+				'   //example.com/page   ',
+				true,
 			],
 		];
 	}

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -137,13 +137,13 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * Relative reference src. All needed params are provided, but the image file is not found there.
 	 */
 	public function test_relative_ref_src_no_local_file() {
-		$src                           = 'path/img.jpg';
+		$src                           = '/path/img.jpg';
 		$folder_local_images           = '/tmp/mock';
 		$default_image_host_and_schema = 'https://deault/download/from';
 
 		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
 
-		$this->assertSame( $default_image_host_and_schema . '/' . $src, $img_import_path );
+		$this->assertSame( $default_image_host_and_schema . $src, $img_import_path );
 	}
 
 	/**
@@ -327,37 +327,37 @@ class Test_Downloader extends WP_UnitTestCase {
 		return [
 			// E.g. 1. intermediate image: returns non-intermediate.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 			],
 			// E.g. 3. non-intermediate image: returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 				null,
 			],
 			// E.g. 4. scaled image (not intermediate): returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
 				null,
 			],
 			// E.g. 5. image with query params: returns non-intermediate without query.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten-300x244.jpg?foo=bar',
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten-300x244.jpg?foo=bar',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 			],
 			// E.g. 6. image with spaces and query params: returns non-intermediate without query and trimmed.
 			[
-				'   https://www.mysite.com/wp-content/uploads/2025/01/kitten-300x244.jpg?foo=bar   ',
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+				'   https://www.example.com/wp-content/uploads/2025/01/kitten-300x244.jpg?foo=bar   ',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 			],
 			// E.g. 7. SVG image (should not match intermediate pattern): returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector-300x244.svg',
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector-300x244.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector.svg',
 			],
 			// E.g. 8. non-intermediate SVG: returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector.svg',
 				null,
 			],
 		];
@@ -372,47 +372,47 @@ class Test_Downloader extends WP_UnitTestCase {
 		return [
 			// E.g. 1. scaled image: returns non-scaled.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy.jpg',
 			],
 			// E.g. 2. non-scaled image: returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/regular_puppy.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/regular_puppy.jpg',
 				null,
 			],
 			// E.g. 3. scaled image with query params: returns non-scaled without query.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg?foo=bar',
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg?foo=bar',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy.jpg',
 			],
 			// E.g. 4. scaled image with spaces and query params: returns non-scaled without query and trimmed.
 			[
-				'   https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg?foo=bar   ',
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy.jpg',
+				'   https://www.example.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg?foo=bar   ',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy.jpg',
 			],
 			// E.g. 5. scaled PNG image: returns non-scaled PNG.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/image-scaled.png',
-				'https://www.mysite.com/wp-content/uploads/2025/01/image.png',
+				'https://www.example.com/wp-content/uploads/2025/01/image-scaled.png',
+				'https://www.example.com/wp-content/uploads/2025/01/image.png',
 			],
 			// E.g. 6. scaled WebP image: returns non-scaled WebP.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/image-scaled.webp',
-				'https://www.mysite.com/wp-content/uploads/2025/01/image.webp',
+				'https://www.example.com/wp-content/uploads/2025/01/image-scaled.webp',
+				'https://www.example.com/wp-content/uploads/2025/01/image.webp',
 			],
 			// E.g. 7. scaled SVG image: returns non-scaled SVG.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector-scaled.svg',
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector-scaled.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector.svg',
 			],
 			// E.g. 8. non-scaled SVG: returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector.svg',
 				null,
 			],
 			// E.g. 9. intermediate image (not scaled): returns null.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
 				null,
 			],
 		];
@@ -427,10 +427,10 @@ class Test_Downloader extends WP_UnitTestCase {
 		return [
 			// Intermediate image.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
 				[
-					'src'                  => 'https://www.mysite.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
-					'src_non_intermediate' => 'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+					'src'                  => 'https://www.example.com/wp-content/uploads/2025/01/kitten-300x244.jpg',
+					'src_non_intermediate' => 'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 					'src_non_scaled'       => null,
 					'title'                => '',
 					'alt'                  => '',
@@ -438,20 +438,20 @@ class Test_Downloader extends WP_UnitTestCase {
 			],
 			// Scaled image.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
 				[
-					'src'                  => 'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
+					'src'                  => 'https://www.example.com/wp-content/uploads/2025/01/huge_puppy-scaled.jpg',
 					'src_non_intermediate' => null,
-					'src_non_scaled'       => 'https://www.mysite.com/wp-content/uploads/2025/01/huge_puppy.jpg',
+					'src_non_scaled'       => 'https://www.example.com/wp-content/uploads/2025/01/huge_puppy.jpg',
 					'title'                => '',
 					'alt'                  => '',
 				],
 			],
 			// Non-intermediate, non-scaled image.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+				'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 				[
-					'src'                  => 'https://www.mysite.com/wp-content/uploads/2025/01/kitten.jpg',
+					'src'                  => 'https://www.example.com/wp-content/uploads/2025/01/kitten.jpg',
 					'src_non_intermediate' => null,
 					'src_non_scaled'       => null,
 					'title'                => '',
@@ -460,9 +460,9 @@ class Test_Downloader extends WP_UnitTestCase {
 			],
 			// SVG intermediate.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector-300x244.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector-300x244.svg',
 				[
-					'src'                  => 'https://www.mysite.com/wp-content/uploads/2025/01/vector-300x244.svg',
+					'src'                  => 'https://www.example.com/wp-content/uploads/2025/01/vector-300x244.svg',
 					'src_non_intermediate' => null,
 					'src_non_scaled'       => null,
 					'title'                => '',
@@ -471,9 +471,9 @@ class Test_Downloader extends WP_UnitTestCase {
 			],
 			// SVG non-intermediate.
 			[
-				'https://www.mysite.com/wp-content/uploads/2025/01/vector.svg',
+				'https://www.example.com/wp-content/uploads/2025/01/vector.svg',
 				[
-					'src'                  => 'https://www.mysite.com/wp-content/uploads/2025/01/vector.svg',
+					'src'                  => 'https://www.example.com/wp-content/uploads/2025/01/vector.svg',
 					'src_non_intermediate' => null,
 					'src_non_scaled'       => null,
 					'title'                => '',

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -38,11 +38,11 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * Plain absolute HTTP src. No other params.
 	 */
 	public function test_absolute_src_no_local_images_folder() {
-		$src                           = 'http://host.com/path/img.jpg';
-		$folder_local_images           = null;
-		$default_image_host_and_schema = null;
+		$src                     = 'http://host.com/path/img.jpg';
+		$folder_local_images     = null;
+		$default_host_and_schema = null;
 
-		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertSame( $src, $img_import_path );
 	}
@@ -51,11 +51,11 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * Plain absolute HTTP src. Path to folder with local images is provided, but the image file is not found there.
 	 */
 	public function test_absolute_src_no_local_file() {
-		$src                           = 'http://host.com/path/img.jpg';
-		$folder_local_images           = '/tmp/mock';
-		$default_image_host_and_schema = null;
+		$src                     = 'http://host.com/path/img.jpg';
+		$folder_local_images     = '/tmp/mock';
+		$default_host_and_schema = null;
 
-		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertSame( $src, $img_import_path );
 	}
@@ -64,28 +64,28 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * Plain absolute HTTP src. Path to folder with local images is provided, and the image file is found locally.
 	 */
 	public function test_absolute_src_with_local_file() {
-		$src                           = 'http://host.com/path/img.jpg';
-		$folder_local_images           = '/tmp/mock';
-		$default_image_host_and_schema = null;
-		$local_file                    = $folder_local_images . '/path/img.jpg';
+		$src                     = 'http://host.com/path/img.jpg';
+		$folder_local_images     = '/tmp/mock';
+		$default_host_and_schema = null;
+		$local_file              = $folder_local_images . '/path/img.jpg';
 
 		// Get partial mock for Downloader::file_exists method, to avoid writing to disk.
 		$partial_mock = $this->create_downloader_partial_mock_with_file_exists_method( $local_file, true );
 
-		$img_import_path = $partial_mock->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $partial_mock->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertSame( $local_file, $img_import_path );
 	}
 
 	/**
-	 * Relative reference to host root. But a WP_Error gets returned if the $default_image_host_and_schema param is not provided.
+	 * Relative reference to host root. But a WP_Error gets returned if the $default_host_and_schema param is not provided.
 	 */
 	public function test_relative_ref_to_root_src_no_local_images_folder_returns_wp_error() {
-		$src                           = '/path/img.jpg';
-		$folder_local_images           = null;
-		$default_image_host_and_schema = null;
+		$src                     = '/path/img.jpg';
+		$folder_local_images     = null;
+		$default_host_and_schema = null;
 
-		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertInstanceOf( WP_Error::class, $img_import_path );
 	}
@@ -94,41 +94,41 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * Relative reference to host root. All needed params are provided, but the image file is not found there.
 	 */
 	public function test_relative_ref_to_root_src_no_local_file() {
-		$src                           = '/path/img.jpg';
-		$folder_local_images           = '/tmp/mock';
-		$default_image_host_and_schema = 'https://deault/download/from';
+		$src                     = '/path/img.jpg';
+		$folder_local_images     = '/tmp/mock';
+		$default_host_and_schema = 'https://deault/download/from';
 
-		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
-		$this->assertSame( $default_image_host_and_schema . $src, $img_import_path );
+		$this->assertSame( $default_host_and_schema . $src, $img_import_path );
 	}
 
 	/**
 	 * Relative reference to host root. The image file is found locally.
 	 */
 	public function test_relative_ref_to_root_src_with_local_file() {
-		$src                           = '/path/img.jpg';
-		$folder_local_images           = '/tmp/mock';
-		$default_image_host_and_schema = 'https://deault/download/from';
-		$local_file                    = $folder_local_images . '/path/img.jpg';
+		$src                     = '/path/img.jpg';
+		$folder_local_images     = '/tmp/mock';
+		$default_host_and_schema = 'https://deault/download/from';
+		$local_file              = $folder_local_images . '/path/img.jpg';
 
 		// Get partial mock for Downloader::file_exists method, to avoid writing to disk.
 		$partial_mock = $this->create_downloader_partial_mock_with_file_exists_method( $local_file, true );
 
-		$img_import_path = $partial_mock->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $partial_mock->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertSame( $local_file, $img_import_path );
 	}
 
 	/**
-	 * Relative reference src. But a WP_Error gets returned if the $default_image_host_and_schema param is not provided.
+	 * Relative reference src. But a WP_Error gets returned if the $default_host_and_schema param is not provided.
 	 */
 	public function test_relative_ref_src_no_local_images_folder_returns_wp_error() {
-		$src                           = 'path/img.jpg';
-		$folder_local_images           = null;
-		$default_image_host_and_schema = null;
+		$src                     = 'path/img.jpg';
+		$folder_local_images     = null;
+		$default_host_and_schema = null;
 
-		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertInstanceOf( WP_Error::class, $img_import_path );
 	}
@@ -137,28 +137,28 @@ class Test_Downloader extends WP_UnitTestCase {
 	 * Relative reference src. All needed params are provided, but the image file is not found there.
 	 */
 	public function test_relative_ref_src_no_local_file() {
-		$src                           = '/path/img.jpg';
-		$folder_local_images           = '/tmp/mock';
-		$default_image_host_and_schema = 'https://deault/download/from';
+		$src                     = '/path/img.jpg';
+		$folder_local_images     = '/tmp/mock';
+		$default_host_and_schema = 'https://deault/download/from';
 
-		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $this->downloader->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
-		$this->assertSame( $default_image_host_and_schema . $src, $img_import_path );
+		$this->assertSame( $default_host_and_schema . $src, $img_import_path );
 	}
 
 	/**
 	 * Relative reference src. The image file is found locally.
 	 */
 	public function test_relative_ref_src_with_local_file() {
-		$src                           = 'path/img.jpg';
-		$folder_local_images           = '/tmp/mock';
-		$default_image_host_and_schema = 'https://deault/download/from';
-		$local_file                    = $folder_local_images . '/path/img.jpg';
+		$src                     = 'path/img.jpg';
+		$folder_local_images     = '/tmp/mock';
+		$default_host_and_schema = 'https://deault/download/from';
+		$local_file              = $folder_local_images . '/path/img.jpg';
 
 		// Get partial mock for Downloader::file_exists method, to avoid writing to disk.
 		$partial_mock = $this->create_downloader_partial_mock_with_file_exists_method( $local_file, true );
 
-		$img_import_path = $partial_mock->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_image_host_and_schema );
+		$img_import_path = $partial_mock->get_fully_qualified_img_import_or_download_path( $src, $folder_local_images, $default_host_and_schema );
 
 		$this->assertSame( $local_file, $img_import_path );
 	}


### PR DESCRIPTION
Extended functionality to work with non-image URLs.
More options, CSV with results, more extended functionality.

These tree commands now exist in the plugin:
1. `scan-existing-urls` -- it lists/scans all image and/or non-image URLs, hostnames and extensions in posts/pages
2. `download-images`
3. `download-non-image-files`
    - added mandatory `--extensions argument`, e.g. `--extensions=pdf,docx,xlsx,pptx`

- renamed command `scan-existing-images-hostnames` to `scan-existing-urls` which now supports image or non-image URLs
    - added `--include-non-image-urls` -- this lists also non-image URLs
    - added `--do-not-download-root-relative-urls`
    - added `--do-not-download-protocol-relative-urls`
    - search for all non-image URLs uses a hybrid approach -- first searching relative and absolute URLs in DOM attributes, then additionally searching HTML as clear text for more absolute HTMLs. This increases chances of coverage, and favors attributes making sure they are not missed.
- the two `download` commands produce CSVs with results
- added support for `srcset`s
- added support for protocol-relative URLs. Now supporting three kinds of URLs:
    - absolute, e.g. `https://server.com/wp-content/uploads/image.jpg`
    - root-relative, e.g. `/wp-content/uploads/image.jpg`
    - protocol-relative, e.g. `//server.com/wp-content/uploads/image.jpg`
- memory optimization
    - added Memory flushing in many places
    - now using more memory-efficient file writing
