### PR TITLE
fix: proper non-intermediate and scaled variables

### DIFF
--- a/cmd_download_images__downloaded.csv
+++ b/cmd_download_images__downloaded.csv
@@ -1,0 +1,1 @@
+post_id,url_original,attachment_id,url_downloaded

--- a/cmd_download_images__downloaded.csv
+++ b/cmd_download_images__downloaded.csv
@@ -1,1 +1,0 @@
-post_id,url_original,attachment_id,url_downloaded

--- a/newspack-post-image-downloader.php
+++ b/newspack-post-image-downloader.php
@@ -5,7 +5,7 @@
  * Plugin URI:  https://newspack.pub/
  * Author:      Automattic
  * Author URI:  https://newspack.pub/
- * Version:     1.3.0
+ * Version:     1.3.1
  *
  * @package  Newspack_Post_Image_Downloader
  */

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -557,8 +557,8 @@ class Downloader {
 			$post_content_updated = $post_content;
 			foreach ( $img_data as $img_datum ) {
 				$src                  = trim( $img_datum['src'] );
-				$src_non_intermediate = isset( $img_datum['src_non_intermediate'] ) && ( ! empty( $img_datum['src_non_intermediate'] ) ? trim( $img_datum['src_non_intermediate'] ) : null );
-				$src_non_scaled       = isset( $img_datum['src_non_scaled'] ) && ! empty( $img_datum['src_non_scaled'] ) ? trim( $img_datum['src_non_scaled'] ) : null;
+				$src_non_intermediate = ! empty( $img_datum['src_non_intermediate'] ) ? trim( $img_datum['src_non_intermediate'] ) : null;
+				$src_non_scaled       = ! empty( $img_datum['src_non_scaled'] ) ? trim( $img_datum['src_non_scaled'] ) : null;
 				$title                = trim( $img_datum['title'] );
 				$alt                  = trim( $img_datum['alt'] );
 


### PR DESCRIPTION
# Description

This PR fixes wrong conditional for `$src_non_intermediate` and `$src_non_scaled`. Because of the way those were defined, the value was set to `true` instead of an actual URL.

```bash
[Init logging at 2025-10-14 13:06:09.000000]
Fetching Posts...
👉 (1/1) post ID 335851, found 3 images...
… adding large non-intermediate image 'https://example.com/wp-content/uploads/2017/09/1AMacomb.jpg' {"post_id":335851,"src":"https://example.com/wp-content/uploads/2017/09/1AMacomb-241x300.jpg"}
… adding large non-intermediate image 'https://example.com/wp-content/uploads/2017/09/2AbatiNPS.jpg' {"post_id":335851,"src":"https://example.com/wp-content/uploads/2017/09/2AbatiNPS-300x139.jpg"}
… adding large non-intermediate image 'https://example.com/wp-content/uploads/2017/09/3CongreveRockets.jpg' {"post_id":335851,"src":"https://example.com/wp-content/uploads/2017/09/3CongreveRockets-300x190.jpg"}
error: ❗ Error getting image path: Could not download unsupported src type 'http://1'. {"post_id":"335851","src":true}
[Dry Run] Imported src 'https://example.com/wp-content/uploads/2017/09/1AMacomb-241x300.jpg' as attachment ID 'dry_run' {"post_id":"335851","src":"https://example.com/wp-content/uploads/2017/09/1AMacomb-241x300.jpg"}
error: ❗ Error getting image path: Could not download unsupported src type 'http://1'. {"post_id":"335851","src":true}
[Dry Run] Imported src 'https://example.com/wp-content/uploads/2017/09/2AbatiNPS-300x139.jpg' as attachment ID 'dry_run' {"post_id":"335851","src":"https://example.com/wp-content/uploads/2017/09/2AbatiNPS-300x139.jpg"}
error: ❗ Error getting image path: Could not download unsupported src type 'http://1'. {"post_id":"335851","src":true}
[Dry Run] Imported src 'https://example.com/wp-content/uploads/2017/09/3CongreveRockets-300x190.jpg' as attachment ID 'dry_run' {"post_id":"335851","src":"https://example.com/wp-content/uploads/2017/09/3CongreveRockets-300x190.jpg"}
All done!  🙌  Took 0 mins.
See the CSV file for results: cmd_download_images__downloaded.csv
```

Check the `error: ❗ Error getting image path: Could not download unsupported src type 'http://1'` line