### PR TITLE
Fix Crawler Attributes Filter (fork - deleted)

### DIFF
--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1700,8 +1700,7 @@ class Downloader {
 			'data-preview',
 		];
 		foreach ( $simple_attributes as $attribute ) {
-			$crawler = $crawler->filter( "[{$attribute}]" );
-			foreach ( $crawler->getIterator() as $node ) {
+			foreach ( $crawler->filter( "[{$attribute}]" ) as $node ) {
 				$urls[] = $node->getAttribute( $attribute );
 			}
 		}

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -721,7 +721,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					// 'relative/audio.mp3', // href attribute is crawled first, but relative urls are filtered out.
+					// href attribute is crawled first, but relative urls are filtered out: 'relative/audio.mp3' .
 					'/absolute/audio.mp3', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -694,10 +694,11 @@ class Test_Downloader extends WP_UnitTestCase {
 				'<img data-src="https://example.com/lazy.jpg" data-background="https://example.com/bg.jpg" alt="Test">',
 				[ 'https://example.com/lazy.jpg', 'https://example.com/bg.jpg' ],
 			],
-			// HTML with video poster.
+			// HTML with video poster and reversed order of attributes.
 			[
 				'<video poster="https://example.com/poster.jpg" src="https://example.com/video.mp4"></video>',
-				[ 'https://example.com/poster.jpg', 'https://example.com/video.mp4' ],
+				// the crawler will capture "src" attribute first, then "poster" based on $simple_attributes array order.
+				[ 'https://example.com/video.mp4', 'https://example.com/poster.jpg' ],
 			],
 			// HTML with absolute URLs in text content.
 			[
@@ -708,6 +709,25 @@ class Test_Downloader extends WP_UnitTestCase {
 			[
 				'<div><a href="https://example.com/link">Link</a><img src="https://example.com/image.jpg" srcset="https://example.com/image-300w.jpg 300w" alt="Test"><p>Visit https://example.com/page for more info</p></div>',
 				[ 'https://example.com/link', 'https://example.com/image.jpg', 'https://example.com/image-300w.jpg', 'https://example.com/page' ],
+			],
+			// Complex HTML with mixed elements, attributes, relative, absolute, protocol-relative, http, https...in mixed attribute order.
+			[
+				'
+					<video poster="//example.com/poster.png"></video>
+					<section data-background="http://example.com/background.jpg"></section>
+					<script src="https://example.com/app.js"></script>
+					<img src="/image.jpg" />
+					<a href="relative/audio.mp3">relative</a>
+					<a href="/absolute/audio.mp3">absolute</a>
+				',
+				[
+					// 'relative/audio.mp3', // href attribute is crawled first, but relative urls are filtered out.
+					'/absolute/audio.mp3', // href attribute is crawled first.
+					'https://example.com/app.js', // src attribute is crawled after href.
+					'/image.jpg', // src attribute is crawled after href.
+					'http://example.com/background.jpg', // data-background is crawled after src, but before poster.
+					'//example.com/poster.png', // post is crawled later.
+				],
 			],
 		];
 	}


### PR DESCRIPTION
**_Deleted: was on a fork - now I have repo access - new PR will be direct on repo_**



The current crawler code is filtering attributes so the first match is elements with `href`, but the second match is elements with `href` _and_ `src`.

https://github.com/Automattic/newspack-post-image-downloader/blob/f331f2378c4020560358193b503775a09dec829c/src/class-downloader.php#L1703-L1704

This new PR fixes this so that each filter runs independently: match elements with `href`, then match elements with `src` independently, etc.

The reason why things seemed to work, is the `get_absolute_urls_from_text` function would actually get the urls. 

https://github.com/Automattic/newspack-post-image-downloader/blob/f331f2378c4020560358193b503775a09dec829c/src/class-downloader.php#L1724

Since all the tests used fully qualified urls, `get_absolute_urls_from_text` was the reason the tests passed.

This PR:
* Fixes the crawler.
* Fixes one test where the attributes are now captured in the correct order by the crawler.
* Adds a test that uses a variety of URL formats and attributes in mixed order.