### PR TITLE
Refactor Get All Urls with in-valid

### DIFF
--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -421,12 +421,17 @@ class Downloader {
 					continue;
 				}
 
-				// Filter by host - skip if URL doesn't match allowed hosts.
+				// Filter by host.
 				if ( $only_scan_hosts ) {
+
+					// If '/' urls are allowed and it's actually a root relative url.
 					$is_allowed_root_relative = in_array( '/', $only_scan_hosts, true ) && $this->is_url_root_relative( $url );
-					$is_matching_host         = $this->does_uri_match_host( $url, $only_scan_hosts );
+
+					// If url matches an allowed host.
+					$is_allowed_host = $this->does_uri_match_host( $url, $only_scan_hosts );
 					
-					if ( ! $is_allowed_root_relative && ! $is_matching_host ) {
+					// Skip the url if both checks are false.
+					if ( ! $is_allowed_root_relative && ! $is_allowed_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					}

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -404,31 +404,19 @@ class Downloader {
 				$url = trim( $url );
 
 				// Validate URL.
-				$is_absolute          = $this->is_url_absolute( $url );
-				$is_root_relative     = $this->is_url_root_relative( $url );
-				$is_protocol_relative = $this->is_url_protocol_relative( $url );
 				if ( ! $this->is_url_valid( $url ) ) {
-					continue;
-				}
-
-				// Get hostname and extension.
-				$url_check = null;
-				if ( $is_absolute || $is_root_relative ) {
-					$url_check = $url;
-				} elseif ( $is_protocol_relative ) {
-					$url_check = 'https:' . $url;
-				} else {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::NOTICE, sprintf( "Skip invalid URL '%s'", $url ), [ 'post_id' => $post_id ] );
 					// Unsupported URL, like `src="data:image/svg+xml;base64"` or invalid URLs.
-					fputcsv( $csv_file_handle, [ $post_id, '', '', $url ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
+					fputcsv( $csv_file_handle, [ $post_id, '', '', 'invalid-url: ' . $url ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 					continue;
 				}
-
+				
 				// Get hostname.
-				$parsed   = wp_parse_url( $url_check );
-				$hostname = $parsed['host'] ?? null;
+				$url_check = $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url;
+				$hostname  = wp_parse_url( $url_check, PHP_URL_HOST );
 
 				// Get extension.
-				$extension = $this->get_url_extension( $url_check );
+				$extension = $this->get_url_extension( $url );
 
 				// Add to CSV.
 				fputcsv( $csv_file_handle, [ $post_id, $hostname, $extension, $url, ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
@@ -448,11 +436,11 @@ class Downloader {
 		// Tada!
 		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total URL hosts', count( $cli_quick_output['hostnames'] ) ) );
 		if ( count( $cli_quick_output['hostnames'] ) > 0 ) {
-			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '- %s', implode( "\n- ", $cli_quick_output['hostnames'] ) ) );
+			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( "\n- %s", implode( "\n- ", $cli_quick_output['hostnames'] ) ) );
 		}
 		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 Found %d total URL extensions -- note that technically extension is everything after the last dot, so use the following list to determine which ones are valid ', count( $cli_quick_output['extensions'] ) ) );
 		if ( count( $cli_quick_output['extensions'] ) > 0 ) {
-			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '- %s', implode( ', ', $cli_quick_output['extensions'] ) ) );
+			$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( "\n- %s", implode( "\n- ", $cli_quick_output['extensions'] ) ) );
 		}
 		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( 'Done in %d mins! 🙌 ', floor( ( microtime( true ) - $time_start ) / 60 ) ) );
 		$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::INFO, sprintf( '👉 See CSV file for full list of post IDs, URLs, hostnames and extensions: %s ', $csv_file ) );
@@ -1672,14 +1660,14 @@ class Downloader {
 	}
 
 	/**
-	 * Gets unique URLs from HTML.
-	 * Supported URL types are absolute, root-relative (e.g. `/path/to/image.jpg`) and protocol-relative (e.g. `//example.com/path/to/image.jpg`), but not `data` B64 or page-relative URLs (e.g. `../page/image.jpg`).
+	 * Gets all URLs from HTML.
+	 * 
 	 * First fetches URLs from various DOM attributes to get the most relevant URLs, and then additionally extracts just potential remaining 
 	 * absolute URLs from text content. This hybrid approach tries to optimize relevance and accuracy.
 	 *
 	 * @param string $html HTML.
 	 *
-	 * @return array An array of unique and valid/supported URLs.
+	 * @return array An array of unique URLs.
 	 */
 	public function get_all_urls_from_html( string $html ): array {
 		$urls    = [];
@@ -1734,15 +1722,7 @@ class Downloader {
 			}
 		);
 		$urls = array_map( 'trim', $urls );
-		
-		// Validate URLs.
-		$urls = array_filter(
-			$urls,
-			function ( $url ) {
-				return $this->is_url_valid( $url );
-			}
-		);
-		
+
 		// Update keys.
 		$urls = array_values( $urls );
 

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -102,7 +102,10 @@ class Downloader {
 					[
 						'type'        => 'assoc',
 						'name'        => 'only-scan-hosts',
-						'description' => 'CSV, list of specific hosts to scan. Can use a wildcard, e.g. to cover a host and all its subdomains, use these two values `somehost.com,*.somehost.com`, or for multiple domain extensions use `www.somehost.*`, or can even use `*.somehost.*` for all subdomains and all domain extensions.
+						'description' => 'CSV, list of specific hosts to scan.
+							- Use a wildcard to cover a host and all its subdomains (e.g.: `somehost.com,*.somehost.com`, or for multiple domain extensions use `www.somehost.*`, or use `*.somehost.*` for all subdomains and all domain extensions.)
+							- Use "/" to include root-relative urls (i.e. starting with `/`, e.g. `/path/to/image.jpg`).
+							- Combine wildcard with root-relative: "somehost.com,*.somehost.com,/"
 						',
 						'optional'    => true,
 						'repeating'   => false,

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -436,15 +436,15 @@ class Downloader {
 					if ( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
 						$allow_host = true;
 					}
-					// Hostname matching.
 					elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
+						// Hostname match.
 						$allow_host = true;
 					}
 
 					if ( ! $allow_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;   
-					}               
+					}
 				}               
 
 				// Get extension.

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -421,26 +421,12 @@ class Downloader {
 					continue;
 				}
 
-				// Get hostname.
-				$parsed_url = wp_parse_url( $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url );
-				$hostname   = $parsed_url['host'] ?? null;
-				
-				// Filter by host.
+				// Filter by host - skip if URL doesn't match allowed hosts.
 				if ( $only_scan_hosts ) {
+					$is_allowed_root_relative = in_array( '/', $only_scan_hosts, true ) && $this->is_url_root_relative( $url );
+					$is_matching_host = $this->does_uri_match_host( $url, $only_scan_hosts );
 					
-					$allow_host = false;
-					
-					// Allow root-relative ("/something...") if '/' was set in --only-scan-hosts,
-					// and hostname is empty, and scheme is not set (http...nor any other schemes like file://, ftp://, etc)
-					// and $url starts with "/".
-					if ( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
-						$allow_host = true;
-					} elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
-						// Hostname match.
-						$allow_host = true;
-					}
-
-					if ( ! $allow_host ) {
+					if ( ! $is_allowed_root_relative && ! $is_matching_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					}
@@ -448,6 +434,9 @@ class Downloader {
 
 				// Get extension.
 				$extension = $this->get_url_extension( $url );
+
+				// Get hostname.
+				$hostname = wp_parse_url( $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url, PHP_URL_HOST );
 
 				// Add to CSV.
 				fputcsv( $csv_file_handle, [ $post_id, $hostname, $extension, $url, ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -443,9 +443,9 @@ class Downloader {
 
 					if ( ! $allow_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
-						continue;   
+						continue;
 					}
-				}               
+				}
 
 				// Get extension.
 				$extension = $this->get_url_extension( $url );

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -421,24 +421,10 @@ class Downloader {
 					continue;
 				}
 
-				// Filter by host.
-				if ( $only_scan_hosts ) {
-
-					$allow_host = false;
-					
-					// Allow root-relative ("/something...") if '/' was set in --only-scan-hosts.
-					if ( in_array( '/', $only_scan_hosts, true ) && $this->is_url_root_relative( $url ) ) {
-						$allow_host = true;
-					}
-					elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
-						// Hostname match.
-						$allow_host = true;
-					}
-
-					if ( ! $allow_host ) {
-						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
-						continue;
-					}
+				// Filter by host.  Check for allowed hosts and maybe '/' root relative too.
+				if ( $only_scan_hosts && ! $this->does_uri_match_host_maybe_root_relative( $url, $only_scan_hosts ) ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+					continue;
 				}
 
 				// Get hostname.
@@ -1492,6 +1478,27 @@ class Downloader {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks whether URI's host matches an array element of the given hosts array (the hosts array supports wildcard),
+	 * maybe also allow '/' root relative if allowed in hosts list.
+	 *
+	 * @param string $uri   URI which host is checked.
+	 * @param array  $hosts Hostnames to check against.
+	 *
+	 * @return false
+	 */
+	public function does_uri_match_host_maybe_root_relative( string $uri, array $hosts ) {
+
+		// If the uri is root relative, then check if '/' is in the allowed $hosts set.
+		if ( $this->is_url_root_relative( $uri ) ) {
+			return in_array( '/', $hosts, true );
+		}
+		
+		// Just do the normal hostname check.
+		return $this->does_uri_match_host( $uri, $hosts );
+
 	}
 
 	/**

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -90,12 +90,12 @@ class Downloader {
 			'newspack-post-image-downloader scan-existing-urls',
 			[ $this, 'cmd_scan_existing_urls' ],
 			[
-				'shortdesc' => 'Searches all existing image URLs in <img> attributes in posts and pages, and lists hostnames and extensions. Useful to ascertain existing hostnames to include/exclude from downloading.',
+				'shortdesc' => 'Searches all existing image URLs in <img src> attributes in posts and pages, and lists hostnames and extensions. Useful to ascertain existing hostnames to include/exclude from downloading.',
 				[
 					[
 						'type'        => 'flag',
 						'name'        => 'include-non-image-urls',
-						'description' => 'By default, only scans <img> elements, but if this flag is set, it will also scan non-image URLs.',
+						'description' => 'By default, only scans image URLs, but if this flag is set, it will also scan non-image URLs.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -432,11 +432,11 @@ class Downloader {
 					}
 				}
 
-				// Get extension.
-				$extension = $this->get_url_extension( $url );
-
 				// Get hostname.
 				$hostname = wp_parse_url( $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url, PHP_URL_HOST );
+
+				// Get extension.
+				$extension = $this->get_url_extension( $url );
 
 				// Add to CSV.
 				fputcsv( $csv_file_handle, [ $post_id, $hostname, $extension, $url, ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
@@ -1630,7 +1630,7 @@ class Downloader {
 	}
 
 	/**
-	 * Gets all the unique <img> `src`, `srcset`, and `data-srcset` URLs from HTML.
+	 * Gets all the unique <img> `src` and `srcset` URLs from HTML.
 	 *
 	 * @param string $html HTML.
 	 *

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -424,14 +424,18 @@ class Downloader {
 				// Filter by host.
 				if ( $only_scan_hosts ) {
 
-					// If '/' urls are allowed and it's actually a root relative url.
-					$is_allowed_root_relative = in_array( '/', $only_scan_hosts, true ) && $this->is_url_root_relative( $url );
-
-					// If url matches an allowed host.
-					$is_allowed_host = $this->does_uri_match_host( $url, $only_scan_hosts );
+					$allow_host = false;
 					
-					// Skip the url if both checks are false.
-					if ( ! $is_allowed_root_relative && ! $is_allowed_host ) {
+					// Allow root-relative ("/something...") if '/' was set in --only-scan-hosts.
+					if ( in_array( '/', $only_scan_hosts, true ) && $this->is_url_root_relative( $url ) ) {
+						$allow_host = true;
+					}
+					elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
+						// Hostname match.
+						$allow_host = true;
+					}
+
+					if ( ! $allow_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
 						continue;
 					}

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -432,7 +432,7 @@ class Downloader {
 					
 					// Allow root-relative ("/something...") if '/' was set in --only-scan-hosts,
 					// and hostname is empty, and scheme is not set (http...nor any other schemes like file://, ftp://, etc)
-					// and $url starts with with "/".
+					// and $url starts with "/".
 					if ( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
 						$allow_host = true;
 					}

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -424,7 +424,7 @@ class Downloader {
 				// Filter by host - skip if URL doesn't match allowed hosts.
 				if ( $only_scan_hosts ) {
 					$is_allowed_root_relative = in_array( '/', $only_scan_hosts, true ) && $this->is_url_root_relative( $url );
-					$is_matching_host = $this->does_uri_match_host( $url, $only_scan_hosts );
+					$is_matching_host         = $this->does_uri_match_host( $url, $only_scan_hosts );
 					
 					if ( ! $is_allowed_root_relative && ! $is_matching_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -435,8 +435,7 @@ class Downloader {
 					// and $url starts with "/".
 					if ( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
 						$allow_host = true;
-					}
-					elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
+					} elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
 						// Hostname match.
 						$allow_host = true;
 					}

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1496,6 +1496,9 @@ class Downloader {
 			return in_array( '/', $hosts, true );
 		}
 		
+		// Remove '/' just incase when doing the hostname matching.
+		$hosts = array_filter( $hosts, fn ( $v ) => trim( $v ) !== '/' );
+
 		// Just do the normal hostname check.
 		return $this->does_uri_match_host( $uri, $hosts );
 	}
@@ -1522,11 +1525,8 @@ class Downloader {
 	 * @return bool True if the URL is relative, false otherwise.
 	 */
 	public function is_url_root_relative( string $url ): bool {
-		$url                    = trim( $url );
-		$ends_with_single_slash = 0 === strpos( $url, '/' );
-		$is_protocol_relative   = $this->is_url_protocol_relative( $url );
-		
-		return $ends_with_single_slash && ! $is_protocol_relative;
+		$url = trim( $url );		
+		return ( 0 === strpos( $url, '/' ) ) && ( 0 !== strpos( $url, '//' ) );
 	}
 
 	/**

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -90,20 +90,20 @@ class Downloader {
 			'newspack-post-image-downloader scan-existing-urls',
 			[ $this, 'cmd_scan_existing_urls' ],
 			[
-				'shortdesc' => 'Searches all existing image URLs in <img src> attributes in posts and pages, and lists hostnames and extensions. Useful to ascertain existing hostnames to include/exclude from downloading.',
+				'shortdesc' => 'Searches all existing image URLs in <img> attributes in posts and pages, and lists hostnames and extensions. Useful to ascertain existing hostnames to include/exclude from downloading.',
 				[
 					[
 						'type'        => 'flag',
 						'name'        => 'include-non-image-urls',
-						'description' => 'By default, only scans image URLs, but if this flag is set, it will also scan non-image URLs.',
+						'description' => 'By default, only scans <img> elements, but if this flag is set, it will also scan non-image URLs.',
 						'optional'    => true,
 						'repeating'   => false,
 					],
 					[
 						'type'        => 'assoc',
 						'name'        => 'only-scan-hosts',
-						// @todo Need full description.
-						'description' => 'CSV, list of specific hosts to scan...',
+						'description' => 'CSV, list of specific hosts to scan. Can use a wildcard, e.g. to cover a host and all its subdomains, use these two values `somehost.com,*.somehost.com`, or for multiple domain extensions use `www.somehost.*`, or can even use `*.somehost.*` for all subdomains and all domain extensions.
+						',
 						'optional'    => true,
 						'repeating'   => false,
 					],
@@ -414,17 +414,35 @@ class Downloader {
 
 				// Validate URL.
 				if ( ! $this->is_url_valid( $url ) ) {
-					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::NOTICE, sprintf( "Skip invalid URL '%s'", $url ), [ 'post_id' => $post_id ] );
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, invalid url '%s'", $url ), [ 'post_id' => $post_id ] );
 					continue;
 				}
-				
-				// Get hostname.
-				$hostname  = wp_parse_url( $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url, PHP_URL_HOST );
 
+				// Get hostname.
+				$parsed_url = wp_parse_url( $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url );
+				$hostname   = $parsed_url['host'] ?? null;
+				
 				// Filter by host.
-				if ( $hostname && $only_scan_hosts && ! $this->does_uri_match_host( '//'. $hostname . '/', $only_scan_hosts ) ) {
-					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
-					continue;
+				if ( $only_scan_hosts ) {
+					
+					$allow_host = false;
+					
+					// Allow root-relative ("/something...") if '/' was set in --only-scan-hosts,
+					// and hostname is empty, and scheme is not set (http...nor any other schemes like file://, ftp://, etc)
+					// and $url starts with with "/".
+					if( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
+						$allow_host = true;
+					}
+					// Hostname matching.
+					else if( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
+						$allow_host = true;
+					}
+
+					if( ! $allow_host ) {
+						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+						continue;	
+					}
+
 				}				
 
 				// Get extension.
@@ -1622,7 +1640,7 @@ class Downloader {
 	}
 
 	/**
-	 * Gets all the unique <img> `src` and `srcset` URLs from HTML.
+	 * Gets all the unique <img> `src`, `srcset`, and `data-srcset` URLs from HTML.
 	 *
 	 * @param string $html HTML.
 	 *

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -433,20 +433,19 @@ class Downloader {
 					// Allow root-relative ("/something...") if '/' was set in --only-scan-hosts,
 					// and hostname is empty, and scheme is not set (http...nor any other schemes like file://, ftp://, etc)
 					// and $url starts with with "/".
-					if( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
+					if ( in_array( '/', $only_scan_hosts, true ) && empty( $hostname ) && ! isset( $parsed_url['scheme'] ) && str_starts_with( $url, '/' ) ) {
 						$allow_host = true;
 					}
 					// Hostname matching.
-					else if( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
+					elseif ( $this->does_uri_match_host( $url, $only_scan_hosts ) ) {
 						$allow_host = true;
 					}
 
-					if( ! $allow_host ) {
+					if ( ! $allow_host ) {
 						$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
-						continue;	
-					}
-
-				}				
+						continue;   
+					}               
+				}               
 
 				// Get extension.
 				$extension = $this->get_url_extension( $url );

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1498,7 +1498,6 @@ class Downloader {
 		
 		// Just do the normal hostname check.
 		return $this->does_uri_match_host( $uri, $hosts );
-
 	}
 
 	/**

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -101,6 +101,14 @@ class Downloader {
 					],
 					[
 						'type'        => 'assoc',
+						'name'        => 'only-scan-hosts',
+						// @todo Need full description.
+						'description' => 'CSV, list of specific hosts to scan...',
+						'optional'    => true,
+						'repeating'   => false,
+					],
+					[
+						'type'        => 'assoc',
 						'name'        => 'post-types',
 						'description' => 'Optional CSV Post types to scan. Defaults are `post,page`',
 						'optional'    => true,
@@ -346,6 +354,7 @@ class Downloader {
 	 */
 	public function cmd_scan_existing_urls( $pos_args, $assoc_args ) {
 		$include_non_image_urls = isset( $assoc_args['include-non-image-urls'] ) ? true : false;
+		$only_scan_hosts        = isset( $assoc_args['only-scan-hosts'] ) ? explode( ',', $assoc_args['only-scan-hosts'] ) : null;
 		$post_types             = isset( $assoc_args['post-types'] ) ? explode( ',', $assoc_args['post-types'] ) : [ 'post', 'page' ];
 		$post_statuses          = isset( $assoc_args['post-statuses'] ) ? explode( ',', $assoc_args['post-statuses'] ) : [ 'publish' ];
 		$post_ids_specific      = isset( $assoc_args['post-ids-csv'] ) ? explode( ',', $assoc_args['post-ids-csv'] ) : null;
@@ -406,14 +415,17 @@ class Downloader {
 				// Validate URL.
 				if ( ! $this->is_url_valid( $url ) ) {
 					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::NOTICE, sprintf( "Skip invalid URL '%s'", $url ), [ 'post_id' => $post_id ] );
-					// Unsupported URL, like `src="data:image/svg+xml;base64"` or invalid URLs.
-					fputcsv( $csv_file_handle, [ $post_id, '', '', 'invalid-url: ' . $url ], ',', '"', '' ); // phpcs:ignore -- WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv.
 					continue;
 				}
 				
 				// Get hostname.
-				$url_check = $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url;
-				$hostname  = wp_parse_url( $url_check, PHP_URL_HOST );
+				$hostname  = wp_parse_url( $this->is_url_protocol_relative( $url ) ? 'https:' . $url : $url, PHP_URL_HOST );
+
+				// Filter by host.
+				if ( $hostname && $only_scan_hosts && ! $this->does_uri_match_host( '//'. $hostname . '/', $only_scan_hosts ) ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, off target host '%s'", $url ), [ 'post_id' => $post_id ] );
+					continue;
+				}				
 
 				// Get extension.
 				$extension = $this->get_url_extension( $url );

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -179,6 +179,22 @@ class Test_Downloader extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the `does_uri_match_host_maybe_root_relative` function.
+	 *
+	 * @dataProvider providerUriHostMatchingMaybeRootRelative
+	 *
+	 * @param string[] $srcs            URIs whose host we're testing.
+	 * @param array    $hosts           Array of hosts to check for.
+	 * @param bool     $result_expected Expected result.
+	 */
+	public function test_uri_host_matching_maybe_root_relative( $srcs, $hosts, $result_expected ) {
+		foreach( $srcs as $src ) {
+			$result_actual = $this->downloader->does_uri_match_host_maybe_root_relative( $src, $hosts );
+			$this->assertSame( $result_expected, $result_actual );
+		}
+	}
+
+	/**
 	 * Tests the `get_non_intermediate_img_url` function.
 	 *
 	 * @dataProvider providerGetNonIntermediateImgUrl
@@ -447,6 +463,26 @@ class Test_Downloader extends WP_UnitTestCase {
 			[
 				'https://www.host1.com/path/img.jpg',
 				[ 'www.host2.*' ],
+				false,
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_uri_host_matching_maybe_root_relative.
+	 *
+	 * @return array[]
+	 */
+	public function providerUriHostMatchingMaybeRootRelative() {
+		return [
+			[
+				[ 'https://host1.com/path/img.jpg', '//youtube.com/video/watch?id=123', '/relative/image.jpg' ],
+				[ 'host1.com', 'youtube.com', '/' ],
+				true,
+			],
+			[
+				[ 'https://www.host1.com/path/img.jpg', '//youtube.com/video/watch?id=123', '///triple-slash/file.txt', '../relative/image.jpg' ],
+				[ '/' ],
 				false,
 			],
 		];
@@ -1083,6 +1119,10 @@ class Test_Downloader extends WP_UnitTestCase {
 			[
 				'   /path/to/page   ',
 				true,
+			],
+			[
+				'///three-slashes/path', // this should fail since it's not a valid url (ie: `wp_parse_url` returns  false)
+				false,
 			],
 		];
 	}

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -736,7 +736,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					'relative/audio.mp3',
+					'relative/audio.mp3', // href attribute is crawled first. Relative URLs are now being returned.
 					'/absolute/audio.mp3', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -736,7 +736,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					// href attribute is crawled first, but relative urls are filtered out: 'relative/audio.mp3' .
+					'relative/audio.mp3',
 					'/absolute/audio.mp3', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.


### PR DESCRIPTION
## PR Changes

### Scan by hosts and root-relative

- Adds `--only-scan-hosts` to allow scanning by host.
- Allows argument value `/` to include root-relative too.

### Refactors loop within `cmd_scan_existing_urls`

- The old logic had an else statement that was never getting hit.  It would have added invalid urls to the output CSV.  I refactored this logic.
- The new logic will only log invalid urls to the `CLI_AND_FILE` to better match how `cmd_download_images` and `cmd_download_non_images_files` handle invalid.
- Hostname parsing was updated for `--only-scan-hosts` and `/` root-relative.
- Off-target hostname logging follows the same pattern as `cmd_download_images` / `cmd_download_non_images_files`.
- Added an extra line-space in the output logging. 


### Removes the invalid check from `get_all_urls_from_html`

- The invalid check in the function was redundant because the loop will do the check.  
- Since `get_all_urls_from_html` is public, this could introduce a **breaking change**.  We could support older versions of this function call by adding a `$do_validation = true` secondary arg and then wrapping the is_valid check in that boolean.  Or deprecate the function and rename to a new function...if needed.  I'm not sure if we need to worry about breaking changes?

### Tests

- Fixes a test to allow `/` urls in the return value.


