### PR TITLE
Fix root relative for slashes

### DIFF
--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1500,7 +1500,7 @@ class Downloader {
 	 */
 	public function is_url_root_relative( string $url ): bool {
 		$url = trim( $url );
-		return ( 0 === strpos( $url, '/' ) ) && ( 0 !== strpos( $url, '//' ) );
+		return ( 0 === strpos( $url, '/' ) ) && ! ( 0 === strpos( $url, '//' ) );
 	}
 
 	/**

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1499,7 +1499,7 @@ class Downloader {
 	 * @return bool True if the URL is relative, false otherwise.
 	 */
 	public function is_url_root_relative( string $url ): bool {
-		$url = trim( $url );		
+		$url = trim( $url );
 		return ( 0 === strpos( $url, '/' ) ) && ( 0 !== strpos( $url, '//' ) );
 	}
 

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1499,11 +1499,8 @@ class Downloader {
 	 * @return bool True if the URL is relative, false otherwise.
 	 */
 	public function is_url_root_relative( string $url ): bool {
-		$url                    = trim( $url );
-		$ends_with_single_slash = 0 === strpos( $url, '/' );
-		$is_protocol_relative   = $this->is_url_protocol_relative( $url );
-		
-		return $ends_with_single_slash && ! $is_protocol_relative;
+		$url = trim( $url );		
+		return ( 0 === strpos( $url, '/' ) ) && ( 0 !== strpos( $url, '//' ) );
 	}
 
 	/**

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -1085,7 +1085,7 @@ class Test_Downloader extends WP_UnitTestCase {
 				true,
 			],
 			[
-				// this should fail since it's not a valid url (ie: `wp_parse_url` returns  false).
+				// this should fail since it's not a valid url (ie: `wp_parse_url` returns false).
 				'///three-slashes/path',
 				false,
 			],

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -1084,6 +1084,10 @@ class Test_Downloader extends WP_UnitTestCase {
 				'   /path/to/page   ',
 				true,
 			],
+			[
+				'///three-slashes/path', // this should fail since it's not a valid url (ie: `wp_parse_url` returns  false)
+				false,
+			],
 		];
 	}
 

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -1085,7 +1085,8 @@ class Test_Downloader extends WP_UnitTestCase {
 				true,
 			],
 			[
-				'///three-slashes/path', // this should fail since it's not a valid url (ie: `wp_parse_url` returns  false)
+				// this should fail since it's not a valid url (ie: `wp_parse_url` returns  false).
+				'///three-slashes/path',
 				false,
 			],
 		];


### PR DESCRIPTION
Fixes `is_url_root_relative` for the case of `///`.

The previous code was:

```
$ends_with_single_slash = 0 === strpos( $url, '/' );
$is_protocol_relative   = $this->is_url_protocol_relative( $url );
return $ends_with_single_slash && ! $is_protocol_relative;
```

In the case of a url starting with `///`, the resulting `return` was `true && ! false` which equates to `true`.  This is because the "ends with" (actually "begins with") is correctly `true`, and `is_url_protocol_relative` is correctly `false`.  

But `///(.*)` is not a parseable url by `wp_parse_url` so this is not a "root relative" url - it's an invalid url.  

The new code is simply:

```
return ( 0 === strpos( $url, '/' ) ) && ! ( 0 === strpos( $url, '//' ) );
```

A test was added to verify this case.  






