### PR TITLE
Fix valid check and log invalid for scan urls

### DIFF
--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1683,7 +1683,7 @@ class Downloader {
 	 * @param string $html     HTML.
 	 * @param bool   $validate Whether to validate URLs. Default `true` will remove in-invalid urls (this is backward compatible).
 	 *
-	 * @return array An array of unique URLs.
+	 * @return array An array of unique URLs. (By default, invalid urls are not returned - control this behavior with the $validate arg.)
 	 */
 	public function get_all_urls_from_html( string $html, bool $validate = true ): array {
 		$urls    = [];

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -960,7 +960,7 @@ class Downloader {
 			MemoryCleanupHook::cleanup();
 
 			// Get all URLs with extensions from HTML.
-			$urls_all        = $this->get_all_urls_from_html( $post_content, false );
+			$urls_all        = $this->get_all_urls_from_html( $post_content );
 			$urls_extensions = [];
 			foreach ( $urls_all as $url ) {
 				// Validate URL.
@@ -1670,7 +1670,7 @@ class Downloader {
 	}
 
 	/**
-	 * Gets all URLs from HTML.
+	 * Gets all unique URLs from HTML.
 	 * 
 	 * First fetches URLs from various DOM attributes to get the most relevant URLs, and then additionally extracts just potential remaining 
 	 * absolute URLs from text content. This hybrid approach tries to optimize relevance and accuracy.
@@ -1734,7 +1734,7 @@ class Downloader {
 		);
 		$urls = array_map( 'trim', $urls );
 		
-		// Filter out invalid URLs if validation is enabled.
+		// Filter out invalid URLs if $validation argument is true.
 		if ( $validate ) {
 			$urls = array_filter(
 				$urls,

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -408,7 +408,7 @@ class Downloader {
 				$is_root_relative     = $this->is_url_root_relative( $url );
 				$is_protocol_relative = $this->is_url_protocol_relative( $url );
 				if ( ! $this->is_url_valid( $url ) ) {
-					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, invalid url '%s'", $url ), [ 'post_id' => $post_id ] );
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Invalid URL type '%s'", $url ), [ 'post_id' => $post_id ] );
 					continue;
 				}
 

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1670,13 +1670,18 @@ class Downloader {
 	}
 
 	/**
-	 * Gets all unique URLs from HTML.
+	 * Gets unique URLs from HTML.
+	 * 
+	 * Supported URL types are absolute, root-relative (e.g. `/path/to/image.jpg`) and protocol-relative (e.g. `//example.com/path/to/image.jpg`).
+	 * 
+	 * By default, invalid urls like `data` B64 or page-relative URLs (e.g. `../page/image.jpg`) are not returned. Set the $validate arg to false
+	 * to turn off validation if you'd like invalid urls to also be returned.
 	 * 
 	 * First fetches URLs from various DOM attributes to get the most relevant URLs, and then additionally extracts just potential remaining 
 	 * absolute URLs from text content. This hybrid approach tries to optimize relevance and accuracy.
 	 *
 	 * @param string $html     HTML.
-	 * @param bool   $validate Whether to filter out invalid URLs. Default true for backward compatibility.
+	 * @param bool   $validate Whether to validate URLs. Default `true` will remove in-invalid urls (this is backward compatible).
 	 *
 	 * @return array An array of unique URLs.
 	 */

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -408,7 +408,7 @@ class Downloader {
 				$is_root_relative     = $this->is_url_root_relative( $url );
 				$is_protocol_relative = $this->is_url_protocol_relative( $url );
 				if ( ! $this->is_url_valid( $url ) ) {
-					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Invalid URL type '%s'", $url ), [ 'post_id' => $post_id ] );
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::ERROR, sprintf( "❗ Invalid URL '%s'", $url ), [ 'post_id' => $post_id ] );
 					continue;
 				}
 

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -395,7 +395,7 @@ class Downloader {
 
 			// Get all URLs, or just image `src`s.
 			$urls = $include_non_image_urls
-				? $this->get_all_urls_from_html( $post_content )
+				? $this->get_all_urls_from_html( $post_content, false )
 				: $this->get_all_img_srcs_from_html( $post_content );
 			if ( empty( $urls ) ) {
 				continue;
@@ -960,7 +960,7 @@ class Downloader {
 			MemoryCleanupHook::cleanup();
 
 			// Get all URLs with extensions from HTML.
-			$urls_all        = $this->get_all_urls_from_html( $post_content );
+			$urls_all        = $this->get_all_urls_from_html( $post_content, false );
 			$urls_extensions = [];
 			foreach ( $urls_all as $url ) {
 				// Validate URL.
@@ -1675,11 +1675,12 @@ class Downloader {
 	 * First fetches URLs from various DOM attributes to get the most relevant URLs, and then additionally extracts just potential remaining 
 	 * absolute URLs from text content. This hybrid approach tries to optimize relevance and accuracy.
 	 *
-	 * @param string $html HTML.
+	 * @param string $html     HTML.
+	 * @param bool   $validate Whether to filter out invalid URLs. Default true for backward compatibility.
 	 *
 	 * @return array An array of unique URLs.
 	 */
-	public function get_all_urls_from_html( string $html ): array {
+	public function get_all_urls_from_html( string $html, bool $validate = true ): array {
 		$urls    = [];
 		$crawler = new Crawler( $html );
 		
@@ -1732,6 +1733,16 @@ class Downloader {
 			}
 		);
 		$urls = array_map( 'trim', $urls );
+		
+		// Filter out invalid URLs if validation is enabled.
+		if ( $validate ) {
+			$urls = array_filter(
+				$urls,
+				function ( $url ) {
+					return $this->is_url_valid( $url );
+				}
+			);
+		}
 		
 		// Update keys.
 		$urls = array_values( $urls );

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1734,7 +1734,7 @@ class Downloader {
 		);
 		$urls = array_map( 'trim', $urls );
 		
-		// Filter out invalid URLs if $validation argument is true.
+		// Filter out invalid URLs if validate argument is true.
 		if ( $validate ) {
 			$urls = array_filter(
 				$urls,

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -1683,7 +1683,7 @@ class Downloader {
 	 * @param string $html     HTML.
 	 * @param bool   $validate Whether to validate URLs. Default `true` will remove in-invalid urls (this is backward compatible).
 	 *
-	 * @return array An array of unique URLs. (By default, invalid urls are not returned - control this behavior with the $validate arg.)
+	 * @return array An array of unique URLs. (By default, only valid/supported URLs are returned - control this behavior with the $validate arg.)
 	 */
 	public function get_all_urls_from_html( string $html, bool $validate = true ): array {
 		$urls    = [];

--- a/src/class-downloader.php
+++ b/src/class-downloader.php
@@ -408,6 +408,7 @@ class Downloader {
 				$is_root_relative     = $this->is_url_root_relative( $url );
 				$is_protocol_relative = $this->is_url_protocol_relative( $url );
 				if ( ! $this->is_url_valid( $url ) ) {
+					$this->log( self::LOG_OUTPUTS['CLI_AND_FILE'], LogLevel::DEBUG, sprintf( "✖ skipping, invalid url '%s'", $url ), [ 'post_id' => $post_id ] );
 					continue;
 				}
 
@@ -1669,14 +1670,14 @@ class Downloader {
 	}
 
 	/**
-	 * Gets unique URLs from HTML.
-	 * Supported URL types are absolute, root-relative (e.g. `/path/to/image.jpg`) and protocol-relative (e.g. `//example.com/path/to/image.jpg`), but not `data` B64 or page-relative URLs (e.g. `../page/image.jpg`).
+	 * Gets all URLs from HTML.
+	 * 
 	 * First fetches URLs from various DOM attributes to get the most relevant URLs, and then additionally extracts just potential remaining 
 	 * absolute URLs from text content. This hybrid approach tries to optimize relevance and accuracy.
 	 *
 	 * @param string $html HTML.
 	 *
-	 * @return array An array of unique and valid/supported URLs.
+	 * @return array An array of unique URLs.
 	 */
 	public function get_all_urls_from_html( string $html ): array {
 		$urls    = [];
@@ -1731,14 +1732,6 @@ class Downloader {
 			}
 		);
 		$urls = array_map( 'trim', $urls );
-		
-		// Validate URLs.
-		$urls = array_filter(
-			$urls,
-			function ( $url ) {
-				return $this->is_url_valid( $url );
-			}
-		);
 		
 		// Update keys.
 		$urls = array_values( $urls );

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -736,7 +736,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					// href attribute is crawled first, but relative urls are filtered out: 'relative/audio.mp3' .
+					'relative/audio.mp3', // href attribute is crawled first. Relative URLs are now being returned.
 					'/absolute/audio.mp3', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -776,18 +776,26 @@ class Test_Downloader extends WP_UnitTestCase {
 					<img src="/image.jpg" />
 					<a href="relative/audio.mp3">relative</a>
 					<a href="/absolute/audio.mp3">absolute</a>
+					<div href="div-href" src="div-src" data-src="div-data-src" srcset="/image-300w.jpg 300w, image-600w.jpg 600w">http://example.com/div-text<div>
 				',
 				[
 					'relative/audio.mp3', // href attribute is crawled first. Invalid URLs are returned when validation is disabled.
 					'/absolute/audio.mp3', // href attribute is crawled first.
+					'div-href', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.
+					'div-src', // src attribute is crawled after href.
+					'div-data-src', // data-src attr.
 					'http://example.com/background.jpg', // data-background is crawled after src, but before poster.
 					'//example.com/poster.png', // poster is crawled later.
+					'/image-300w.jpg', // srcset after all attributes.
+					'image-600w.jpg', // srcset after all attributes.
+					'http://example.com/div-text', // full url scan.
 				],
 			],
 		];
 	}
+
 
 	/**
 	 * DataProvider for test_get_urls_from_srcset.

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -251,6 +251,19 @@ class Test_Downloader extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the `get_all_urls_from_html` function with validation disabled.
+	 *
+	 * @dataProvider providerGetAllUrlsFromHtmlNoValidation
+	 *
+	 * @param string $html            The HTML content to parse.
+	 * @param array  $result_expected The expected array of URLs.
+	 */
+	public function test_get_all_urls_from_html_no_validation( $html, $result_expected ) {
+		$result_actual = $this->downloader->get_all_urls_from_html( $html, false );
+		$this->assertSame( $result_expected, $result_actual );
+	}
+
+	/**
 	 * Tests the `get_urls_from_srcset` function.
 	 *
 	 * @dataProvider providerGetUrlsFromSrcset
@@ -736,12 +749,40 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					'relative/audio.mp3', // href attribute is crawled first. Relative URLs are now being returned.
+					'/absolute/audio.mp3', // href attribute is crawled first. Root-relative URLs are valid.
+					'https://example.com/app.js', // src attribute is crawled after href.
+					'/image.jpg', // src attribute is crawled after href.
+					'http://example.com/background.jpg', // data-background is crawled after src, but before poster.
+					'//example.com/poster.png', // poster is crawled later. Protocol-relative URLs are valid.
+				],
+			],
+		];
+	}
+
+	/**
+	 * DataProvider for test_get_all_urls_from_html_no_validation.
+	 *
+	 * @return array[]
+	 */
+	public function providerGetAllUrlsFromHtmlNoValidation() {
+		return [
+			// Complex HTML with mixed elements including invalid relative URLs.
+			[
+				'
+					<video poster="//example.com/poster.png"></video>
+					<section data-background="http://example.com/background.jpg"></section>
+					<script src="https://example.com/app.js"></script>
+					<img src="/image.jpg" />
+					<a href="relative/audio.mp3">relative</a>
+					<a href="/absolute/audio.mp3">absolute</a>
+				',
+				[
+					'relative/audio.mp3', // href attribute is crawled first. Relative URLs are returned when validation is disabled.
 					'/absolute/audio.mp3', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.
 					'http://example.com/background.jpg', // data-background is crawled after src, but before poster.
-					'//example.com/poster.png', // post is crawled later.
+					'//example.com/poster.png', // poster is crawled later.
 				],
 			],
 		];

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -749,6 +749,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
+					// href attribute is crawled first, but relative urls are filtered out by default: 'relative/audio.mp3' .
 					'/absolute/audio.mp3', // href attribute is crawled first. Root-relative URLs are valid.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.
@@ -777,7 +778,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					'relative/audio.mp3', // href attribute is crawled first. Relative URLs are returned when validation is disabled.
+					'relative/audio.mp3', // href attribute is crawled first. Invalid URLs are returned when validation is disabled.
 					'/absolute/audio.mp3', // href attribute is crawled first.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.

--- a/tests/unit/class-test-downloader.php
+++ b/tests/unit/class-test-downloader.php
@@ -749,7 +749,7 @@ class Test_Downloader extends WP_UnitTestCase {
 					<a href="/absolute/audio.mp3">absolute</a>
 				',
 				[
-					// href attribute is crawled first, but relative urls are filtered out by default: 'relative/audio.mp3' .
+					// href attribute is crawled first, but relative urls are filtered out: 'relative/audio.mp3' .
 					'/absolute/audio.mp3', // href attribute is crawled first. Root-relative URLs are valid.
 					'https://example.com/app.js', // src attribute is crawled after href.
 					'/image.jpg', // src attribute is crawled after href.


### PR DESCRIPTION
## Reason for this PR

Existing commands `wp newspack-post-image-downloader download-images` and `wp newspack-post-image-downloader download-images` log **invalid urls** to `CLI_AND_FILE` as seen [here](https://github.com/Automattic/newspack-post-image-downloader/blob/6ce8ccea9d852f902ae9281c94034bb0b091a144/src/class-downloader.php#L574) and [here](https://github.com/Automattic/newspack-post-image-downloader/blob/6ce8ccea9d852f902ae9281c94034bb0b091a144/src/class-downloader.php#L967).

This PR makes it so `wp newspack-post-image-downloader scan-existing-urls` will now also log the **invalids urls** just like the other commands.

<img width="814" height="157" alt="npid-scan-invalid" src="https://github.com/user-attachments/assets/668af815-7d61-4929-a843-67ad358de045" />

This is really helpful to see all the **invalid urls** during the scanning phase instead of having to run a download in order to see the invalid urls.

## Changes

### Scanning urls function:

- The call to `get_all_urls_from_html` will use the new `$validate` argument set to `false` to allow invalid to be returned just like the other commands.
- Invalid urls will be logged to `CLI_AND_FILE` like `cmd_download_images` and `cmd_download_non_images_files` do.

### Updates the `get_all_urls_from_html` to allow turning validation off.

- The invalid check in the function can be redundant if the calling code does the checking in loop already.  
- Since `get_all_urls_from_html` is public, this could introduce a **breaking change**.  For backward compatibility a secondary argument `$validate = true` was added.

### Tests

- Updated tests for `get_all_urls_from_html` with validation on (default) and also off.

